### PR TITLE
Refactored ModbusChannel to use ACE mutexes instead of boost

### DIFF
--- a/Common/Libraries/ModbusChannel/include/ModbusChannel.h
+++ b/Common/Libraries/ModbusChannel/include/ModbusChannel.h
@@ -1,13 +1,14 @@
 #ifndef MODBUSCHANNEL_HPP
 #define MODBUSCHANNEL_HPP
 
+#include <acsThread.h>
+#include <IRA>
 #include <modbus/modbus.h>
 #include <sys/time.h>
 #include <string>
 #include <cerrno>
 #include <stdexcept>
 #include <boost/shared_ptr.hpp>
-#include <boost/thread.hpp>
 
 #define MODBUS_DEFAULT_PORT MODBUS_TCP_DEFAULT_PORT
 #define MODBUS_TIMEOUT 2
@@ -89,7 +90,7 @@ class ModbusChannel
         T get(int address); //throw ModbusError
     private:
         /* class members */
-        boost::mutex _connection_guard;
+        BACIMutex  _connection_guard;
         std::string _server_ip;
         int _server_port;
         bool _is_connected;

--- a/Common/Libraries/ModbusChannel/src/Makefile
+++ b/Common/Libraries/ModbusChannel/src/Makefile
@@ -23,7 +23,7 @@
 
 #
 # additional include and library search paths
-#USER_INC = 
+#USER_INC =
 #USER_LIB = 
 
 #
@@ -62,7 +62,7 @@ LIBRARIES_L     =
 #
 # <brief description of lllll library>
 ModbusChannel_OBJECTS   = ModbusChannel
-ModbusChannel_LIBS      = modbus boost_thread
+ModbusChannel_LIBS      = modbus acsnc
 
 #
 # Scripts (public and local)

--- a/Common/Libraries/ModbusChannel/src/ModbusChannel.cpp
+++ b/Common/Libraries/ModbusChannel/src/ModbusChannel.cpp
@@ -53,7 +53,7 @@ ModbusChannel::~ModbusChannel()
 void
 ModbusChannel::connect()
 {
-    boost::mutex::scoped_lock lock(_connection_guard);
+    baci::ThreadSyncGuard lock(&_connection_guard);
     int rc;
     if(!(this->_is_connected))
     {
@@ -66,7 +66,7 @@ ModbusChannel::connect()
 void
 ModbusChannel::disconnect()
 {
-    boost::mutex::scoped_lock lock(_connection_guard);
+    baci::ThreadSyncGuard lock(&_connection_guard);
     if(this->_is_connected){
         modbus_close(this->_modbus_context);
         this->_is_connected = false;


### PR DESCRIPTION
ModbusChannel library used boost libraries for implementing scoped locks and mutexes around a couple of the functions declared in the library which need to be executed atomically. 

This was causing the library not to compile in the newest ACS release, I tried to solve it using boost but it seems like it is linking towards the ACS provided boost instead of the system ones and I am not able to solve this issue. 

So I gave a look at other pieces of code in discos using thread guards and i replaced the boost mutexes with baci ones. Now it compiles but I had never used those before so I am asking for a review to check if I am using the library in the correct way. **It is just 7 lines of code, should not take a long time.** 

fixes #95 