### PR TITLE
Fix #181, removed redundant inheritance in SRTKBandDerotator interface.

### DIFF
--- a/SRT/Interfaces/SRTReceiversInterface/idl/SRTKBandDerotator.idl
+++ b/SRT/Interfaces/SRTReceiversInterface/idl/SRTKBandDerotator.idl
@@ -10,7 +10,7 @@
 
 module Receivers {
 
-    interface SRTKBandDerotator : ACS::CharacteristicComponent, GenericDerotator {
+    interface SRTKBandDerotator : GenericDerotator {
  
         /** Computation of the sensor lenght
          *


### PR DESCRIPTION
Tested with SRT, it fixed the issue #181.