### PR TITLE
Fix #238, fixed the return value error of `SRTLPBandReceiver/src/Configuration.cpp::getTaperTable()`.

### DIFF
--- a/SRT/Servers/SRTLPBandReceiver/src/Configuration.cpp
+++ b/SRT/Servers/SRTLPBandReceiver/src/Configuration.cpp
@@ -762,7 +762,7 @@ DWORD CConfiguration::getTaperTable(double * &freq,double *&taper, short feed) c
 			count++;
         }
     }
-    return m_taperVectorLen;
+    return count;
 }
 
 DWORD CConfiguration::getLeftMarkTable(double *& freq, double *& markValue, short feed) const


### PR DESCRIPTION
This has been tested on site with a quick observation, it appears to be the correct solution, but it should be tested again properly when completing the 64-bit migration.