### PR TITLE
Fix #251. Fixed round dependendy for Sardara.

### DIFF
--- a/Common/Servers/Sardara/include/CommandLine.h
+++ b/Common/Servers/Sardara/include/CommandLine.h
@@ -15,7 +15,7 @@
 #include <BackendsErrors.h>
 #include <SardaraS.h>
 #include <TotalPowerS.h>
-#include <SRTIFDistributorS.h>
+#include <GenericIFDistributorS.h>
 #include <string>
 #include <sstream>
 #include <DiscosBackendProtocol>

--- a/Common/Servers/Sardara/src/Makefile
+++ b/Common/Servers/Sardara/src/Makefile
@@ -62,7 +62,7 @@ LIBRARIES       = SardaraImpl
 LIBRARIES_L     =
 
 SardaraImpl_OBJECTS = SardaraImpl Configuration CommandLine SenderThread ControlThread
-SardaraImpl_LIBS = IRALibrary GenericBackendStubs SardaraStubs TotalPowerStubs ManagmentDefinitionsStubs ReceiversDefinitionsStubs BackendsDefinitionsStubs bulkDataStubs bulkDataSenderStubs SRTIFDistributorStubs\
+SardaraImpl_LIBS = IRALibrary GenericBackendStubs SardaraStubs TotalPowerStubs ManagmentDefinitionsStubs ReceiversDefinitionsStubs BackendsDefinitionsStubs bulkDataStubs bulkDataSenderStubs GenericIFDistributorStubs\
   bulkDataReceiverStubs ACSBulkDataError ComponentErrors BackendsErrors ParserErrors ManagementErrors \
   DiscosBackendProtocolLib
 

--- a/SystemMake/Makefile
+++ b/SystemMake/Makefile
@@ -34,7 +34,7 @@ COMMON_LIBRARIES:=SlaLibrary IRALibrary TextWindowLibrary ParserLibrary \
 COMMON_SERVERS:=AntennaBoss Observatory OTF PointingModel Refraction SkySource \
                 Moon FitsWriter Scheduler ReceiversBoss ExternalClients \
                 CalibrationTool TotalPower NoiseGenerator CustomLogger \
-                XBackend PyDewarPositioner Sardara #DBBC 
+                XBackend PyDewarPositioner Sardara PyLocalOscillator #DBBC
 COMMON_CLIENTS:=AntennaBossTextClient ObservatoryTextClient \
                 GenericBackendTextClient ReceiversBossTextClient \
                 SystemTerminal CaltoolClient CustomLoggingClient \
@@ -49,7 +49,7 @@ SRT_INTERFACES:=SRTAntennaInterface SRTActiveSurfaceInterface \
 SRT_LIBRARIES:=SRTMinorServoLibrary
 SRT_SERVERS:=SRTMount SRTActiveSurfaceLanServer SRTActiveSurfaceUSDServer \
              SRTActiveSurfaceBoss SRTMinorServo SRTKBandMFReceiver \
-             SRTWeatherStation SRT7GHzReceiver SRTLPBandReceiver
+             SRTWeatherStation SRT7GHzReceiver SRTLPBandReceiver SRTPyIFDistributor
 SRT_CLIENTS:=SRTActiveSurfaceGUIClient SRTMountTextClient \
              MinorServoBossTextClient MeteoClient
 SRT_MISC:=SRTScripts
@@ -81,7 +81,7 @@ ifeq ($(STATION),SRT)
 		SlaLibrary IRALibrary TextWindowLibrary ParserLibrary XarcosLibrary SRTMinorServoLibrary ComponentProxy ModbusChannel PyTestingLibrary \
 		AntennaBoss Observatory OTF PointingModel Refraction SkySource Moon FitsWriter Scheduler ReceiversBoss ExternalClients CalibrationTool TotalPower NoiseGenerator DBBC CustomLogger XBackend \
 		SRTMount SRTActiveSurfaceLanServer SRTActiveSurfaceUSDServer SRTActiveSurfaceBoss SRTMinorServo SRTKBandMFReceiver SRTWeatherStation SRT7GHzReceiver SRTLPBandReceiver PyDewarPositioner \
-		AntennaBossTextClient ObservatoryTextClient GenericBackendTextClient ReceiversBossTextClient SystemTerminal CaltoolClient CustomLoggingClient SchedulerTextClient \
+		SRTPyIFDistributor AntennaBossTextClient ObservatoryTextClient GenericBackendTextClient ReceiversBossTextClient SystemTerminal CaltoolClient CustomLoggingClient SchedulerTextClient \
 		SRTActiveSurfaceGUIClient SRTMountTextClient MinorServoBossTextClient \
 		Plotter KStars SRTScripts 
 


### PR DESCRIPTION
Now Sardara depends on GenericIFDistributor and not anymore from SRTPyIFDistributor. Also, added SRTPyIFDistributor to SystemMake/Makefile for automated installation.