### PR TITLE
fix issue #305: Problem related to the visualization of the azimuth a…

### DIFF
--- a/Medicina/Clients/MedicinaMountTextClient/include/MedicinaMountTextClient.h
+++ b/Medicina/Clients/MedicinaMountTextClient/include/MedicinaMountTextClient.h
@@ -34,7 +34,7 @@
 	ACS_SHORT_LOG((LM_INFO,"Trying to get property "#NAME"...")); \
 	NAME=COMPONENT->NAME(); \
 	if (NAME.ptr()!=TYPE::_nil()) { \
-		ACS_LOG(LM_SOURCE_INFO,"mountTui::Main()",(LM_DEBUG,"OK, reference is: %x",NAME.ptr())); \
+		ACS_LOG(LM_SOURCE_INFO,"mountTui::Main()",(LM_DEBUG,"OK, reference is: %lx",(unsigned long)NAME.ptr())); \
 	} \
 	else { \
 		_EXCPT(ClientErrors::CouldntAccessPropertyExImpl,impl,"mountTui::Main()"); \

--- a/Medicina/Clients/MedicinaMountTextClient/src/MedicinaMountTextClient.cpp
+++ b/Medicina/Clients/MedicinaMountTextClient/src/MedicinaMountTextClient.cpp
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]) {
 	componentName=info->name;
 	acu=Antenna::MedicinaMount::_narrow(obj.in());
 	
-	ACS_LOG(LM_SOURCE_INFO,"mountTui::Main()",(LM_DEBUG,"OK, reference is: %d",acu.ptr()));
+	ACS_LOG(LM_SOURCE_INFO,"mountTui::Main()",(LM_DEBUG,"OK, reference is: %ld",(long)acu.ptr()));
 	ACE_OS::sleep(1);
 	try {	
 		/* Get ACS properties */
@@ -314,7 +314,7 @@ int main(int argc, char *argv[]) {
 		_TW_SET_COMPONENT(section_box,42,18,16,1,BLACK_WHITE,CStyle::BOLD,outputField);
 		_TW_SET_COMPONENT(mountStatus_box,42,19,16,1,BLACK_WHITE,CStyle::BOLD,outputField);
 		
-		strcpy(formatString,"% 010.5lf");
+		strcpy(formatString,"%010.5f");
 		azimuth_field->setFormatFunction(CFormatFunctions::floatingPointFormat,static_cast<const char*>(formatString));	
 		elevation_field->setFormatFunction(CFormatFunctions::floatingPointFormat,static_cast<const char*>(formatString));	
 		azimuthError_field->setFormatFunction(CFormatFunctions::floatingPointFormat,static_cast<const char*>(formatString));		

--- a/Medicina/Servers/MedicinaMount/src/ACUData.cpp
+++ b/Medicina/Servers/MedicinaMount/src/ACUData.cpp
@@ -28,14 +28,14 @@ void CACUData::setMonitorBuffer(BYTE* buffer,WORD size)
 
 double CACUData::azimuth() const
 {
-	long Value;
+	int Value;
 	memcpy(&Value,(m_MonitorData+10),4);
 	return ((double)Value)/1000000.0;
 }
 
 double CACUData::elevation() const
 {
-	long Value;
+	int Value;
 	memcpy(&Value,(m_MonitorData+14),4);
 	return ((double)Value)/1000000.0;	
 }
@@ -68,14 +68,14 @@ double CACUData::elevationRate()
 
 double CACUData::elevationError() const
 {
-	long Value;
+	int Value;
 	memcpy(&Value,(m_MonitorData+22),4);
 	return ((double)Value)/1000000.0;
 }
 
 double CACUData::azimuthError() const
 {
-	long Value;
+	int Value;
 	memcpy(&Value,(m_MonitorData+18),4);
 	return ((double)Value)/1000000.0;
 }
@@ -202,7 +202,8 @@ void CACUData::absTime(TIMEVALUE& tm) const
 
 void CACUData::time(TIMEDIFFERENCE& tm) const
 {
-	long timeofday,hour,minute,second,micro;
+	int timeofday;
+	long hour,minute,second,micro;
 	short dayofyear;
 	memcpy(&timeofday,(m_MonitorData+4),4);
 	memcpy(&dayofyear,(m_MonitorData+8),2);


### PR DESCRIPTION
…nd elevation in the moutTui of Medicina is now solved.

The issue was due to the porting from 32 to 64 bits platform, particularly the length of long integers (8 bytes).
During the decoding of the status message from the ACU the elevation and azimuth values were bitwise copied from the buffer
into a long variable. The elevaion and azimuth i the ACU status is 4 bytes long so the most significant part of the internal
variable wo not initialized.