### PR TITLE
Fix issue #319

### DIFF
--- a/Common/Servers/MFKBandBaseReceiver/src/MFKBandBaseCore.cpp
+++ b/Common/Servers/MFKBandBaseReceiver/src/MFKBandBaseCore.cpp
@@ -23,6 +23,7 @@ void CComponentCore::initialize(maci::ContainerServices* services)
     m_localOscillatorDevice=Receivers::LocalOscillator::_nil();
     m_localOscillatorFault=false;
     m_cryoCoolHead=m_cryoCoolHeadWin= m_cryoLNA=m_cryoLNAWin=m_vacuum=0.0;
+    m_envTemperature=20.0;
     m_fetValues.VDL=m_fetValues.IDL=m_fetValues.VGL=m_fetValues.VDR=m_fetValues.IDR=m_fetValues.VGR=0.0;
     m_statusWord=0;
     m_ioMarkError = false;
@@ -252,7 +253,7 @@ void CComponentCore::externalCalOff() throw (
 void CComponentCore::deactivate() throw (ReceiversErrors::NoRemoteControlErrorExImpl,ReceiversErrors::ReceiverControlBoardErrorExImpl)
 {
 	// no guard needed.
-	
+	m_setupMode="";
 	/*************************************************************************************/
 	/**************************************************************************************/	
 	//lnaOff(); // throw (ReceiversErrors::NoRemoteControlErrorExImpl,ReceiversErrors::ReceiverControlBoardErrorExImpl)

--- a/Common/Servers/ReceiversBoss/src/RecvBossCore_mc.i
+++ b/Common/Servers/ReceiversBoss/src/RecvBossCore_mc.i
@@ -411,7 +411,6 @@ void CRecvBossCore::setup(const char * code) throw (ComponentErrors::SocketError
 			throw impl;
 		}
 		changeBossStatus(Management::MNG_OK);
-		ACS_LOG(LM_FULL_INFO,"CRecvBossCore::setup()",(LM_NOTICE,"NEW_RECEIVER_CONFIGURED %s",code));		
 
 		m_currentRecvCode="KKC";
 		m_currentOperativeMode="NORMAL";
@@ -1214,7 +1213,7 @@ void CRecvBossCore::getBandWidth(ACS::doubleSeq& bw)  throw  (ComponentErrors::C
 		}
 		else {
 			bw.length(m_bandWidth_.length());
-			for (unsigned i=0;i<m_bandWidth_.length();i++) bw[i]=m_bandWidth[i];
+			for (unsigned i=0;i<m_bandWidth_.length();i++) bw[i]=m_bandWidth_[i];
 		}
 	}	
 	else {
@@ -1268,7 +1267,7 @@ void CRecvBossCore::getInitialFrequency(ACS::doubleSeq& iFreq)  throw  (Componen
 		}	
 		else {
 			iFreq.length(m_startFreq_.length());
-			for (unsigned i=0;i<m_startFreq_.length();i++) iFreq[i]=m_startFreq[i];
+			for (unsigned i=0;i<m_startFreq_.length();i++) iFreq[i]=m_startFreq_[i];
 		}	
 	}
 	else {	

--- a/Medicina/Configuration/CDB/alma/RECEIVERS/Boss/Boss.xml
+++ b/Medicina/Configuration/CDB/alma/RECEIVERS/Boss/Boss.xml
@@ -26,7 +26,7 @@
 
 <AvailableReceiver Code="CCC" Derotator="false" Component=""/>
 
-<AvailableReceiver Code="KKC" Derotator="true" Component="RECEIVERS/KBandDualFReceiver"/>
+<AvailableReceiver Code="KKC" Derotator="false" Component="RECEIVERS/KBandDualFReceiver"/>
 
 <AvailableReceiver Code="XXP" Derotator="false" Component=""/>
 

--- a/Medicina/Configuration/CDB/alma/RECEIVERS/KBandDualFReceiver/KBandDualFReceiver.xml
+++ b/Medicina/Configuration/CDB/alma/RECEIVERS/KBandDualFReceiver/KBandDualFReceiver.xml
@@ -23,7 +23,7 @@
     LNAPort="10001"      
     WatchDogResponseTime="10000000"
     WatchDogSleepTime="10000000"
-    LNASamplingTime="1000000"
+    LNASamplingTime="250000"
     RepetitionCacheTime="7000000"
     RepetitionExpireTime="10000000"
     LocalOscillatorInstance="RECEIVERS/LO"


### PR DESCRIPTION
Fixed a small bug in the receivers boss introduced by recoding of Medicina implementation.

The Boss client now check if the derotator is available before trying to load it. This should save an erro from the manger in systems without
a derotator.
Some changes in Medicina configuration regarding the receivers management.