### PR TITLE
Porting hotfix issue #317 into master

### DIFF
--- a/SRT/Configuration/CDB/alma/WEATHERSTATION/WeatherStation/WeatherStation.xml
+++ b/SRT/Configuration/CDB/alma/WEATHERSTATION/WeatherStation/WeatherStation.xml
@@ -3,7 +3,7 @@
     - History:
        -   Tue Jul 10 13:47:38 UTC 2012 modified by jDAL
 -->
-<WeatherStation xmlns="urn:schemas-cosylab-com:WeatherStation:1.0" xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" IPAddress="192.168.202.66" port="5000" windthreshold="50" >
+<WeatherStation xmlns="urn:schemas-cosylab-com:WeatherStation:1.0" xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" IPAddress="192.168.202.66" port="5000" windthreshold="60" >
 	<temperature description="current temperature" units="deg Celsius" />
 	<winddir description="instantaneous wind direction" units="deg" />
 	<windspeed description="average wind speed" units="km/s" max_value="5" />


### PR DESCRIPTION
The threshold for wind autopark at the SRT has been increased to 60 from 50 Km/h (#321)