### PR TITLE
Merging hotfix issue 334 into master:  (#335)

### DIFF
--- a/SRT/Misc/SRTScripts/src/receiversmonitor.py
+++ b/SRT/Misc/SRTScripts/src/receiversmonitor.py
@@ -11,26 +11,32 @@ from Acspy.Util.ACSCorba import getManager
 
 process = os.path.basename(__file__)
 # Exit in case the user try to run the script on nuraghe-mng
-if 'nuraghe-mng' in os.getenv('HOST'):
-    print 'ERROR: you can not execute %s on this machine.' % process
-    print 'Please, read the SD manual!'
-    sys.exit(0)
+#if 'nuraghe-mng' in os.getenv('HOST'):
+#    print 'ERROR: you can not execute %s on this machine.' % process
+#    print 'Please, read the SD manual!'
+#    sys.exit(0)
 
 # Exit in case the process is already running
 running_processes = os.popen("ps aux").read()
 counter = 0
 for line in running_processes.split('\n'):
     if 'python' in line and process in line:
-        if str(os.getpid()) in line.split():
-            continue
-        else:
-            counter += 1
+#        if str(os.getpid()) in line.split():
+#            continue
+#        else:
+        counter += 1
     if counter > 1:
         print '%s already running, everything is OK' % process
         sys.exit(0)
 
-LOGDIR = os.path.join(os.getenv('HOME'), 'logs', 'receivers')
-FILENAME = os.path.join(LOGDIR, 'receivers.log')
+#LOGDIR = os.path.join('service','receivers')
+LOGDIR ='/service/receivers'
+FILENAME = os.path.join(LOGDIR,'receivers.log')
+dirname=os.path.dirname(LOGDIR)
+if not os.path.exists(dirname):
+	print 'ERROR: target folder does not exists, check %s' % LOGDIR
+	sys.exit(-1)
+	
 logging.basicConfig(
     filename=FILENAME,
     format='%(asctime)s\t%(message)s')


### PR DESCRIPTION
* fix issue 334: changed the python script that automatically reads the receivers status. The script is now suited to run
on top of master workstation. The target file is /service/receivers/receivers.log

* fix issue 334: modified according to the PR review.