### PR TITLE
Fix #353, fixed Noto discos --start procedure.

### DIFF
--- a/Noto/Misc/NotoScripts/app-defaults/discosStartup.xml
+++ b/Noto/Misc/NotoScripts/app-defaults/discosStartup.xml
@@ -26,7 +26,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>WeatherStationContainer</name>
@@ -35,7 +35,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>MountContainer</name>
@@ -44,7 +44,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>FrontEndsContainer</name>
@@ -53,7 +53,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>AntennaContainer</name>
@@ -62,7 +62,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>LocalOscillator</name>
@@ -71,7 +71,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>ReceiversContainer</name>
@@ -80,7 +80,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>TotalPowerContainer</name>
@@ -89,7 +89,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>ManagementContainer</name>
@@ -98,7 +98,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>FitsZillaContainer</name>
@@ -107,7 +107,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>CalibrationToolContainer</name>
@@ -116,7 +116,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>PointContainer</name>
@@ -125,7 +125,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>NotoActiveSurfaceContainer</name>
@@ -134,7 +134,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>NotoMinorServoContainer</name>
@@ -143,7 +143,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
         <container>
             <name>ExternalClientsContainer</name>
@@ -152,7 +152,7 @@
             <useDedicatedSettings>true</useDedicatedSettings>
             <scriptBase>0</scriptBase>
             <remoteHost>MASTERHOST</remoteHost>
-            <remoteAccount></remoteAccount>
+            <remoteAccount>discos</remoteAccount>
         </container>
     </containers>
 </AcsCommandCenterProject>


### PR DESCRIPTION
The `discos` user was missing from containers startup configuration using native ssh.