### PR TITLE
fix #359: The Noto mount component exposes a bad date and time readou…

### DIFF
--- a/Medicina/Servers/MedicinaMount/src/ACUData.cpp
+++ b/Medicina/Servers/MedicinaMount/src/ACUData.cpp
@@ -180,7 +180,13 @@ int CACUData::getError() const
 
 void CACUData::absTime(TIMEVALUE& tm) const
 {
-	long timeofday,hour,minute,second,micro;
+	//*************************************////
+	//* This is a fix for an identified issue related to to readout of ACU time.
+	// The issue was originated by the 64bit platform when memcpying into a long (8bytes)
+	// instead of int (4 bytes)
+	//long timeofday,hour,minute,second,micro;
+	int timeofday;
+	long hour,minute,second,micro;
 	short dayofyear;
 	memcpy(&timeofday,(m_MonitorData+4),4);
 	memcpy(&dayofyear,(m_MonitorData+8),2);


### PR DESCRIPTION
…t from the ACU. This readout

is employed in coordinate computation in order to check if the telescope is tracking or not.
This problem was due to the 32 to 64 bits migration particularly a memcpy from a ACU buffer to
an integer. This integer was 4 byte long in the 32 bits architecture while was 8 bytes in the 64 bits.
The result of that was an inversion of LSB and MSB .