### PR TITLE
Fix #377, TimeTaggedCircularArray::selectPoint refactored

### DIFF
--- a/Common/Libraries/IRALibrary/include/TimeTaggedCircularArray.h
+++ b/Common/Libraries/IRALibrary/include/TimeTaggedCircularArray.h
@@ -12,6 +12,7 @@
 /* Andrea Orlati(aorlati@ira.inaf.it) 31/01/2008      changed the algorithm of selectPoint()                                          */
 /* Andrea Orlati(aorlati@ira.inaf.it) 31/01/2008      fixed a bug in selectPoint() that causes  problem when longitude crosses the 360  */
 /* Andrea Orlati(aorlati@ira.inaf.it) 08/09/2010      added the averagePoint method */
+/* Giuseppe Carboni(giuseppe.carboni@inaf.it) 30/04/2019 changed algorithm and return value of selectPoint() */
 
 #include <acstimeEpochHelper.h>
 #include "Definitions.h"
@@ -117,8 +118,9 @@ public:
 	 * @param time the mark of time used to select the point
 	 * @param azimuth azimuth coordinate of the point
 	 * @param elevation elevation coordinate of the point 
+	 * @return false if the returned value is uncertain, true otherwise
 	 */
-	void selectPoint(const TIMEVALUE& time,double& azimuth,double& elevation) const;
+	bool selectPoint(const TIMEVALUE& time,double& azimuth,double& elevation) const;
 	
 	/**
 	 * This method can be used to get a point given two marks of time. The point is the result of the average of all points included between the two marks.

--- a/Common/Libraries/IRALibrary/src/TimeTaggedCircularArray.cpp
+++ b/Common/Libraries/IRALibrary/src/TimeTaggedCircularArray.cpp
@@ -137,7 +137,7 @@ bool CTimeTaggedCircularArray::selectPoint(const TIMEVALUE& time, double& azimut
 		}
 	}
 
-	if(pp == m_head) {
+	if(pp == m_head && time < m_array[m_head].time) {
 		// The requested time is smaller than all other points in the vector
 		azimuth = m_array[m_head].azimuth;
 		elevation = m_array[m_head].elevation;

--- a/Common/Servers/AntennaBoss/src/BossCore.cpp
+++ b/Common/Servers/AntennaBoss/src/BossCore.cpp
@@ -230,7 +230,8 @@ void CBossCore::getObservedHorizontal(TIMEVALUE& time,TIMEDIFFERENCE& duration,d
 	}
 	else {
 		TIMEVALUE midTime(time.value().value+duration.value().value/2);
-		m_observedHorizontals.selectPoint(midTime,az,el);
+		if(!m_observedHorizontals.selectPoint(midTime,az,el))
+			ACS_LOG(LM_FULL_INFO,"CBossCore::getObservedHorizontal()", (LM_WARNING, "ACU COORDINATES UNCERTAINTY!"));
 	}
 }
 
@@ -248,7 +249,8 @@ void CBossCore::getObservedEquatorial(TIMEVALUE& time,TIMEDIFFERENCE& duration,d
 	else {
 		//printf("Short integration\n");
 		TIMEVALUE midTime(time.value().value+duration.value().value/2);
-		m_observedEquatorials.selectPoint(midTime,ra,dec);
+		if(!m_observedEquatorials.selectPoint(midTime,ra,dec))
+			ACS_LOG(LM_FULL_INFO,"CBossCore::getObservedEquatorial()", (LM_WARNING, "ACU COORDINATES UNCERTAINTY!"));
 	}
 }
 
@@ -264,7 +266,8 @@ void CBossCore::getObservedGalactic(TIMEVALUE& time,TIMEDIFFERENCE& duration,dou
 	}
 	else {
 		TIMEVALUE midTime(time.value().value+duration.value().value/2);
-		m_observedGalactics.selectPoint(midTime,lng,lat);
+		if(!m_observedGalactics.selectPoint(midTime,lng,lat))
+			ACS_LOG(LM_FULL_INFO,"CBossCore::getObservedGalactic()", (LM_WARNING, "ACU COORDINATES UNCERTAINTY!"));
 	}
 }
 
@@ -273,7 +276,8 @@ void CBossCore::getRawHorizontal(const TIMEVALUE& time,double& az,double& el) co
 	//IRA::CString tempo;
 	//IRA::CIRATools::timeToStr(time.value().value,tempo);
 	//printf("getRaw: %s ",(const char *)tempo);
-	m_rawCoordinates.selectPoint(time,az,el);
+	if(!m_rawCoordinates.selectPoint(time,az,el))
+		ACS_LOG(LM_FULL_INFO,"CBossCore::getRawHorizontal()", (LM_WARNING, "ACU COORDINATES UNCERTAINTY!"));
 	//printf("%lf %lf\n",az,el);
 }
 

--- a/Medicina/Servers/MedicinaMount/src/MedicinaMountSocket.cpp
+++ b/Medicina/Servers/MedicinaMount/src/MedicinaMountSocket.cpp
@@ -509,7 +509,8 @@ double CMedicinaMountSocket::getCommandedAzimuth(bool ptEnabled)
 		TIMEVALUE now;
 		double azimuth,elevation;
 		CIRATools::getTime(now);
-		m_trackStack->selectPoint(now,azimuth,elevation);
+		if(!m_trackStack->selectPoint(now,azimuth,elevation))
+			ACS_LOG(LM_FULL_INFO,"CMedicinaMountSocket::getCommandedAzimuth()", (LM_WARNING, "ACU COORDINATES UNCERTAINTY!"));
 		return azimuth;
 	}
 	else { 
@@ -523,7 +524,8 @@ double CMedicinaMountSocket::getCommandedElevation(bool ptEnabled)
 		TIMEVALUE now;
 		double azimuth,elevation;
 		CIRATools::getTime(now);
-		m_trackStack->selectPoint(now,azimuth,elevation);
+		if(!m_trackStack->selectPoint(now,azimuth,elevation))
+			ACS_LOG(LM_FULL_INFO,"CMedicinaMountSocket::getCommandedAzimuth()", (LM_WARNING, "ACU COORDINATES UNCERTAINTY!"));
 		return elevation;
 	}
 	else { 


### PR DESCRIPTION
Now the method waits for a maximum of 2 seconds for a new point to be inserted into the array when a set of coordinates with a too recent timestamp is requested. If no point is received, it return the last set of known coordinates and a boolean value of `false` indicating that the returned pair of coordinates is uncertain. This boolean value can be useful in case we want to log the event from the caller module (i.e. from the `AntennaBoss` module).