### PR TITLE
Fix #387, added some building process files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ Common/Interfaces/ManagmentInterface/idl/CustomLogger.idl
 Common/Interfaces/ReceiversInterface/idl/DewarPositionerDefinitions.idl
 Common/Interfaces/XBackendInterface/idl/XBackends.idl
 Common/Misc/PMUpdate/src/PMUpdate_gui.py
+Noto/Errors/NotoActiveSurfaceErrors/idl/ASErrors.idl
+Noto/Interfaces/NotoActiveSurfaceInterface/idl/NotoActiveSurfaceBoss.idl
 SRT/Clients/SRTActiveSurfaceGUIClient/include/SRTActiveSurfaceGUI.h
 SRT/Clients/SRTActiveSurfaceGUIClient/src/moc_SRTActiveSurfaceCore.cpp
 SRT/Clients/SRTActiveSurfaceGUIClient/src/moc_SRTActiveSurfaceGUIui.cpp


### PR DESCRIPTION
The `.gitignore` file misses the Medicina and Noto build process files to ignore. I will add them as soon as possible.

- [x] Common
- [x] SRT
- [x] Noto
- [x] Medicina