### PR TITLE
Some other improvements to the SRT active surface servers and clients

### DIFF
--- a/SRT/Clients/SRTActiveSurfaceGUIClient/src/SRTActiveSurfaceCore.cpp
+++ b/SRT/Clients/SRTActiveSurfaceGUIClient/src/SRTActiveSurfaceCore.cpp
@@ -72,44 +72,8 @@ void SRTActiveSurfaceCore::run(void)
     ACS::pattern asProfile_val;
 
 
-    while (monitor == true) {
-
-        bossStatus_var = tASBoss->status();
-        bossStatus_val = bossStatus_var->get_sync(completion.out());
-        switch (bossStatus_val) {
-            case (Management::MNG_OK):
-                ASstatusCode = 0;
-                break;
-            case (Management::MNG_WARNING):
-                ASstatusCode = -1;
-                break;
-            case (Management::MNG_FAILURE):
-                ASstatusCode = -2;
-                break;
-        }
-        emit setGUIasStatusCode();
-
-        asProfile_var = tASBoss->pprofile();
-        asProfile_val = asProfile_var->get_sync(completion.out());
-        switch (asProfile_val) {
-            case (ActiveSurface::AS_SHAPED):
-                asProfileCode = 0;
-                break;
-            case (ActiveSurface::AS_SHAPED_FIXED):
-                asProfileCode = 1;
-                break;
-            case (ActiveSurface::AS_PARABOLIC):
-                asProfileCode = 2;
-                break;
-            case (ActiveSurface::AS_PARABOLIC_FIXED):
-                asProfileCode = 3;
-                break;
-            case (ActiveSurface::AS_PARK):
-                asProfileCode = 4;
-                break;
-        }
-        emit setGUIasProfileCode();
-
+    while (monitor == true)
+    {
         if (totalactuators >= 1 && totalactuators <= 24) // 1 circle
             i= 1;
         if (totalactuators >= 25 && totalactuators <= 48)  // 2 circle
@@ -151,6 +115,47 @@ void SRTActiveSurfaceCore::run(void)
 			totalactuators == 817 || totalactuators == 913 || totalactuators == 1009 ||
             totalactuators == 1105 || totalactuators == 1113 || totalactuators == 1117)      
             l = 1;
+
+        //set the current USD color to yellow to identify which one is being checked
+        theActuatorStatusColorString = "background-color: rgb(255, 255, 0);";
+        emit setGUIActuatorColor(i, l, theActuatorStatusColorString);
+		CIRATools::Wait(0,10000);
+
+        bossStatus_var = tASBoss->status();
+        bossStatus_val = bossStatus_var->get_sync(completion.out());
+        switch (bossStatus_val) {
+            case (Management::MNG_OK):
+                ASstatusCode = 0;
+                break;
+            case (Management::MNG_WARNING):
+                ASstatusCode = -1;
+                break;
+            case (Management::MNG_FAILURE):
+                ASstatusCode = -2;
+                break;
+        }
+        emit setGUIasStatusCode();
+
+        asProfile_var = tASBoss->pprofile();
+        asProfile_val = asProfile_var->get_sync(completion.out());
+        switch (asProfile_val) {
+            case (ActiveSurface::AS_SHAPED):
+                asProfileCode = 0;
+                break;
+            case (ActiveSurface::AS_SHAPED_FIXED):
+                asProfileCode = 1;
+                break;
+            case (ActiveSurface::AS_PARABOLIC):
+                asProfileCode = 2;
+                break;
+            case (ActiveSurface::AS_PARABOLIC_FIXED):
+                asProfileCode = 3;
+                break;
+            case (ActiveSurface::AS_PARK):
+                asProfileCode = 4;
+                break;
+        }
+        emit setGUIasProfileCode();
 
         try {
             tASBoss->usdStatus4GUIClient(i,l,status);
@@ -216,7 +221,6 @@ void SRTActiveSurfaceCore::run(void)
 		actuatorcounter = l;
 		totacts = totalactuators;
 
-		CIRATools::Wait(0,100000);
 	} // end of while
 }
 

--- a/SRT/Interfaces/SRTActiveSurfaceInterface/idl/usd.idl
+++ b/SRT/Interfaces/SRTActiveSurfaceInterface/idl/usd.idl
@@ -185,6 +185,16 @@ module ActiveSurface
     	*/
     	oneway void top();
     	oneway void bottom();
+
+        /**
+        *   Get the last read status of the USD
+        */
+        long getStatus();
+
+        /**
+        *   Update the status of the USD
+        */
+        oneway void updateStatus();
 	};
 
 };

--- a/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossCore.h
+++ b/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossCore.h
@@ -121,6 +121,10 @@ public:
 
     void sectorActiveSurface(int sector) throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx);
 
+    void checkUSD(int sector, int lanIndex, int circleIndex, int usdCircleIndex, std::string serial_usd) throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx);
+
+    void sectorSetupCompleted(int sector);
+
     void watchingActiveSurfaceStatus() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::CouldntGetAttributeExImpl, ComponentErrors::ComponentNotActiveExImpl);
 
     void usdStatus4GUIClient(int circle, int actuator, CORBA::Long_out status) throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::CouldntGetAttributeExImpl, ComponentErrors::ComponentNotActiveExImpl);

--- a/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossSectorThread.h
+++ b/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossSectorThread.h
@@ -49,18 +49,21 @@ public:
       * This method overrides the thread implementation class.
       * The thread can be exited by calling ACS::ThreadBase::stop or ACS::ThreadBase::exit command.
      */
-     virtual void run();
+     virtual void runLoop();
 
      /**
       * This method is used to set the sector to be initialized. It MUST be called before starting the thread execution
      */
-     virtual void setSector(int sector);
+     virtual void prepare(int sector);
 
 private:
 
     IRA::CSecureArea<CSRTActiveSurfaceBossCore> *m_core;
     CSRTActiveSurfaceBossCore *boss;
-    int m_sector;
+    int m_sector, m_index, m_usd_count;
+    bool m_ready;
+    std::vector<int> m_lanIndexes, m_circleIndexes, m_usdCircleIndexes;
+    std::vector<std::string> m_serial_usds;
 };
 
 #endif /*_SRTACTIVESURFACEBOSSSECTORTHREAD_H_*/

--- a/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossWorkingThread.h
+++ b/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossWorkingThread.h
@@ -27,7 +27,7 @@ public:
      * @param responseTime thread's heartbeat response time in 100ns unit. Default value is 1s.
      * @param sleepTime thread's sleep time in 100ns unit. Default value is 100ms.
     */
-	CSRTActiveSurfaceBossWorkingThread(const ACE_CString& name,IRA::CSecureArea<CSRTActiveSurfaceBossCore>  *param, 
+	CSRTActiveSurfaceBossWorkingThread(const ACE_CString& name,CSRTActiveSurfaceBossCore *param,
 			const ACS::TimeInterval& responseTime=ThreadBase::defaultResponseTime,const ACS::TimeInterval& sleepTime=ThreadBase::defaultSleepTime);
 
 	/**
@@ -52,8 +52,7 @@ public:
      virtual void runLoop();
 
 private:
-
-	IRA::CSecureArea<CSRTActiveSurfaceBossCore> *m_core;
+	CSRTActiveSurfaceBossCore *boss;
 };
 
 #endif /*_SRTACTIVESURFACEBOSSWORKINGTHREAD_H_*/

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossCore.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossCore.cpp
@@ -28,10 +28,16 @@ void CSRTActiveSurfaceBossCore::initialize()
 	{
 		m_sector.push_back(false);
 		usdCounters.push_back(0);
-		lanIndexes.push_back(0);
-		circleIndexes.push_back(0);
-		usdCircleIndexes.push_back(0);
 	}
+
+	for(int i = 0; i < CIRCLES+2; i++)
+	{
+		for(int j = 0; j < ACTUATORS+2; j++)
+		{
+			usd[i][j] = ActiveSurface::USD::_nil();
+		}
+	}
+
 	m_profileSetted = false;
 	m_ASup = false;
 }
@@ -146,55 +152,54 @@ void CSRTActiveSurfaceBossCore::cleanUp()
 
 	ACS_LOG(LM_FULL_INFO, "CSRTActiveSurfaceBossCore::cleanUp()", (LM_INFO,"Releasing usd...wait"));
 
-    for(int sector = 0; sector < SECTORS; sector++)
-    {
-        std::stringstream value;
-        value << CDBPATH;
-        value << "alma/AS/tab_convUSD_S";
-        value << sector+1;
-        value << ".txt";
+	for(int sector = 0; sector < SECTORS; sector++)
+	{
+		std::stringstream value;
+		value << CDBPATH;
+		value << "alma/AS/tab_convUSD_S";
+		value << sector+1;
+		value << ".txt";
 
-        ifstream usdTable(value.str().c_str());
-        std::string buffer;
+		ifstream usdTable(value.str().c_str());
+		std::string buffer;
 
-        while(getline(usdTable, buffer))
-        {
-            std::stringstream line;
-            line << buffer;
-            line >> lanIndex >> circleIndex >> usdCircleIndex >> serial_usd >> graf >> mecc;
+		while(getline(usdTable, buffer))
+		{
+			std::stringstream line;
+			line << buffer;
+			line >> lanIndex >> circleIndex >> usdCircleIndex >> serial_usd >> graf >> mecc;
 
-            try
-            {
-                if(!CORBA::is_nil(usd[circleIndex][usdCircleIndex]))
-                {
-                    printf("releasing usd = %s\n", serial_usd);
-                    m_services->releaseComponent((const char*)serial_usd);
-                }
-            }
-            catch(maciErrType::CannotReleaseComponentExImpl& ex)
-            {
-                _ADD_BACKTRACE(ComponentErrors::CouldntReleaseComponentExImpl,Impl,ex,"CSRTActiveSurfaceBossCore::cleanUp()");
-                Impl.setComponentName((const char *)serial_usd);
-                Impl.log(LM_DEBUG);
-            }
-        }
-    }
-
-    try
-    {
-        m_services->releaseComponent((const char*)m_antennaBoss->name());
-    }
-    catch(maciErrType::CannotReleaseComponentExImpl& ex)
-    {
-        _ADD_BACKTRACE(ComponentErrors::CouldntReleaseComponentExImpl,Impl,ex,"CSRTActiveSurfaceBossCore::cleanUp()");
-        Impl.setComponentName((const char *)m_antennaBoss->name());
-        Impl.log(LM_DEBUG);
-    }
+			try
+			{
+				if (!CORBA::is_nil(usd[circleIndex][usdCircleIndex]))
+				{
+					printf("releasing usd = %s\n", serial_usd);
+					m_services->releaseComponent((const char*)serial_usd);
+				}
+			}
+			catch (maciErrType::CannotReleaseComponentExImpl & ex)
+			{
+				_ADD_BACKTRACE(ComponentErrors::CouldntReleaseComponentExImpl,Impl,ex,"CSRTActiveSurfaceBossCore::cleanUp()");
+				Impl.setComponentName((const char *)serial_usd);
+				Impl.log(LM_DEBUG);
+			}
+		}
+	}
+	try
+	{
+		m_services->releaseComponent((const char*)m_antennaBoss->name());
+	}
+	catch (maciErrType::CannotReleaseComponentExImpl& ex)
+	{
+		_ADD_BACKTRACE(ComponentErrors::CouldntReleaseComponentExImpl,Impl,ex,"CSRTActiveSurfaceBossCore::cleanUp()");
+		Impl.setComponentName((const char *)m_antennaBoss->name());
+		Impl.log(LM_DEBUG);
+	}
 }
 
 void CSRTActiveSurfaceBossCore::reset (int circle, int actuator, int radius) throw (ComponentErrors::UnexpectedExImpl, ComponentErrors::CouldntCallOperationExImpl, ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentNotActiveExImpl)
 {
-    if (circle == 0 && actuator == 0 &&radius == 0) // ALL
+    if (circle == 0 && actuator == 0 && radius == 0) // ALL
 	{
         	int i, l;
 		for (i = 1; i <= CIRCLES; i++)
@@ -1019,7 +1024,7 @@ void CSRTActiveSurfaceBossCore::onewayAction(ActiveSurface::TASOneWayAction onew
                                 				usd[i][l]->setProfile(profile);
                                 			break;
                         			}
-						//CIRATools::Wait(500);
+						CIRATools::Wait(100); //this allows the status4GUI method to be completed without starving
 					}
 					catch (ASErrors::ASErrorsEx& E) {
 						_ADD_BACKTRACE(ComponentErrors::CouldntCallOperationExImpl,impl,E,"CSRTActiveSurfaceBossCore::onewayAction()");
@@ -1092,7 +1097,7 @@ void CSRTActiveSurfaceBossCore::onewayAction(ActiveSurface::TASOneWayAction onew
                         case ActiveSurface::AS_PROFILE:
                             break;
                     }
-					//CIRATools::Wait(LOOPTIME);
+					CIRATools::Wait(100); //this allows the status4GUI method to be completed without starving
                 }
 				catch (ComponentErrors::ComponentErrorsEx& E) {
 					    _ADD_BACKTRACE(ComponentErrors::CouldntCallOperationExImpl,impl,E,"CSRTActiveSurfaceBossCore::oneWayAction()");
@@ -1164,7 +1169,7 @@ void CSRTActiveSurfaceBossCore::onewayAction(ActiveSurface::TASOneWayAction onew
                         case ActiveSurface::AS_PROFILE:
                             break;
                     }
-					//CIRATools::Wait(LOOPTIME);
+					CIRATools::Wait(100); //this allows the status4GUI method to be completed without starving
                 }
                 catch (ComponentErrors::ComponentErrorsEx& E) {
 					    _ADD_BACKTRACE(ComponentErrors::CouldntCallOperationExImpl,impl,E,"CSRTActiveSurfaceBossCore::oneWayAction()");
@@ -1349,50 +1354,38 @@ void CSRTActiveSurfaceBossCore::watchingActiveSurfaceStatus() throw (ComponentEr
     //printf("NO error\n");
 }
 
-void CSRTActiveSurfaceBossCore::sectorActiveSurface(int sector) throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx)
+void CSRTActiveSurfaceBossCore::checkUSD(int sector, int lanIndex, int circleIndex, int usdCircleIndex, std::string serial_usd) throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx)
 {
-	if (sector == -1) {
-		ACS_SHORT_LOG ((LM_INFO, "You have to set a sector first!"));
-		exit(-1);
-	}
-
-	printf("sector%d start\n", sector+1);
-	char serial_usd[23];
-	char graf[5], mecc[4];
-	std::stringstream value;
-	value << CDBPATH;
-	value << "alma/AS/tab_convUSD_S";
-	value << sector+1;
-	value << ".txt";
-
-	ifstream usdTable(value.str().c_str());
-	if (!usdTable) {
-		ACS_SHORT_LOG ((LM_INFO, "File %s not found", value.str().c_str()));
-		exit(-1);
-	}
-
-	// Get reference to usd components
-	while (usdTable >> lanIndexes[sector] >> circleIndexes[sector] >> usdCircleIndexes[sector] >> serial_usd >> graf >> mecc)
+	if(CORBA::is_nil(usd[circleIndex][usdCircleIndex]))
 	{
-		usd[circleIndexes[sector]][usdCircleIndexes[sector]] = ActiveSurface::USD::_nil();
-
 		try
 		{
-			printf("S%d: circleIndexS%d = %d, usdCircleIndexS%d = %d\n", sector+1, sector+1, circleIndexes[sector], sector+1, usdCircleIndexes[sector]);
-			usd[circleIndexes[sector]][usdCircleIndexes[sector]] = m_services->getComponent<ActiveSurface::USD>(serial_usd);
-			lanradius[circleIndexes[sector]][lanIndexes[sector]] = usd[circleIndexes[sector]][usdCircleIndexes[sector]];
+			printf("S%d: circleIndexS%d = %d, usdCircleIndexS%d = %d\n", sector+1, sector+1, circleIndex, sector+1, usdCircleIndex);
+
+
+			lanradius[circleIndex][lanIndex] = usd[circleIndex][usdCircleIndex] = m_services->getComponent<ActiveSurface::USD>(serial_usd.c_str());
 			usdCounters[sector]++;
 		}
 		catch (maciErrType::CannotGetComponentExImpl& ex)
 		{
-			_ADD_BACKTRACE(ComponentErrors::CouldntGetComponentExImpl,Impl,ex,"CSRTActiveSurfaceBossCore::sectorActiveSurface()");
-			Impl.setComponentName(serial_usd);
+			_ADD_BACKTRACE(ComponentErrors::CouldntGetComponentExImpl,Impl,ex,"CSRTActiveSurfaceBossCore::checkUSD()");
+			Impl.setComponentName(serial_usd.c_str());
 			Impl.log(LM_DEBUG);
 		}
 	}
+	else
+	{
+		usd[circleIndex][usdCircleIndex]->updateStatus();
+	}
+}
 
-	printf("sector%d done\n", sector+1);
-	m_sector[sector] = true;
+void CSRTActiveSurfaceBossCore::sectorSetupCompleted(int sector)
+{
+	if(!m_sector[sector])
+	{
+		printf("sector%d done\n", sector+1);
+		m_sector[sector] = true;
+	}
 }
 
 void CSRTActiveSurfaceBossCore::workingActiveSurface() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx)
@@ -1643,30 +1636,26 @@ void CSRTActiveSurfaceBossCore::setActuator(int circle, int actuator, long int& 
 void CSRTActiveSurfaceBossCore::usdStatus4GUIClient(int circle, int actuator, CORBA::Long_out status) throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::CouldntGetAttributeExImpl, ComponentErrors::ComponentNotActiveExImpl)
 {
 	ACS::ROpattern_var status_var;
-    	ACSErr::Completion_var completion;
+	ACSErr::Completion_var completion;
 
-    	if (!CORBA::is_nil(usd[circle][actuator])) {
-        	try {
-            		status_var = usd[circle][actuator]->status ();
-            		status = status_var->get_sync (completion.out ());
-        	}
-        	catch (CORBA::SystemException& ex) {
-            		_EXCPT(ComponentErrors::CORBAProblemExImpl,impl,"CSRTActiveSurfaceBossCore::usdStatus4GUIClient()");
-            		impl.setName(ex._name());
-			impl.setMinor(ex.minor());
-            		throw impl;
+	if (!CORBA::is_nil(usd[circle][actuator]))
+	{
+		try
+		{
+			status = usd[circle][actuator]->getStatus();
 		}
-        /*CompletionImpl local(completion);
-        if (!local.isErrorFree()) {
-            _ADD_BACKTRACE(ComponentErrors::CouldntGetAttributeExImpl,impl,local,"CSRTActiveSurfaceBossCore::usdStatus4GUIClient()");
-			impl.setComponentName((const char*)usd[circle][actuator]->name());
-			impl.setAttributeName("usd status");
+		catch (CORBA::SystemException& ex)
+		{
+			_EXCPT(ComponentErrors::CORBAProblemExImpl,impl,"CSRTActiveSurfaceBossCore::usdStatus4GUIClient()");
+			impl.setName(ex._name());
+			impl.setMinor(ex.minor());
 			throw impl;
-		}*/
-    	}
-    	else {
-        	_THROW_EXCPT(ComponentErrors::ComponentNotActiveExImpl,"CSRTActiveSurfaceBossCore::usdStatus4GUIClient()");
-    	}
+		}
+	}
+	else
+	{
+		_THROW_EXCPT(ComponentErrors::ComponentNotActiveExImpl,"CSRTActiveSurfaceBossCore::usdStatus4GUIClient()");
+	}
 }
 
 void CSRTActiveSurfaceBossCore::recoverUSD(int circleIndex, int usdCircleIndex) throw (ComponentErrors::CouldntGetComponentExImpl)
@@ -1994,3 +1983,4 @@ void CSRTActiveSurfaceBossCore::checkAScompletionerrors (char *str, int circle, 
       break;
     }
 }
+

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossSectorThread.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossSectorThread.cpp
@@ -6,6 +6,9 @@ CSRTActiveSurfaceBossSectorThread::CSRTActiveSurfaceBossSectorThread(const ACE_C
     AUTO_TRACE("CSRTActiveSurfaceBossSectorThread::CSRTActiveSurfaceBossSectorThread()");
     boss = param;
     m_sector = -1;
+    m_index = 0;
+    m_usd_count = 0;
+    m_ready = false;
 }
 
 CSRTActiveSurfaceBossSectorThread::~CSRTActiveSurfaceBossSectorThread()
@@ -23,19 +26,59 @@ void CSRTActiveSurfaceBossSectorThread::onStop()
     AUTO_TRACE("CSRTActiveSurfaceBossSectorThread::onStop()");
 }
 
-void CSRTActiveSurfaceBossSectorThread::setSector(int sector)
+void CSRTActiveSurfaceBossSectorThread::prepare(int sector)
 {
+    if(m_ready) return;
+    m_ready = true;
+
+    //for setup phase we set the sleep time to 1ms in order to be fast
+    this->setSleepTime(10000);
+
     m_sector = sector;
+
+    printf("sector%d start\n", m_sector + 1);
+    std::stringstream value;
+    value << CDBPATH;
+    value << "alma/AS/tab_convUSD_S";
+    value << m_sector + 1;
+    value << ".txt";
+
+    ifstream usdTable(value.str().c_str());
+    if (!usdTable)
+    {
+        ACS_SHORT_LOG ((LM_INFO, "File %s not found", value.str().c_str()));
+        ACS::ThreadBase::exit();
+    }
+
+    std::string serial_usd, graf, mecc;
+    int lanIndex, circleIndex, usdCircleIndex;
+    while(usdTable >> lanIndex >> circleIndex >> usdCircleIndex >> serial_usd >> graf >> mecc)
+    {
+        m_usd_count++;
+        m_lanIndexes.push_back(lanIndex);
+        m_circleIndexes.push_back(circleIndex);
+        m_usdCircleIndexes.push_back(usdCircleIndex);
+        m_serial_usds.push_back(serial_usd);
+    }
+    usdTable.close();
 }
 
-void CSRTActiveSurfaceBossSectorThread::run()
+void CSRTActiveSurfaceBossSectorThread::runLoop()
 {
     try
     {
-        boss->sectorActiveSurface(m_sector);
+        boss->checkUSD(m_sector, m_lanIndexes[m_index], m_circleIndexes[m_index], m_usdCircleIndexes[m_index], m_serial_usds[m_index]);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex)
     {
         ex.log(LM_DEBUG);
+    }
+
+    m_index++;
+    if(m_index == m_usd_count)
+    {
+        this->setSleepTime(1000000); //setup phase ended, set the sleep time at 100ms
+        boss->sectorSetupCompleted(m_sector);
+        m_index = 0;
     }
 }

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossWorkingThread.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossWorkingThread.cpp
@@ -1,7 +1,7 @@
 #include "SRTActiveSurfaceBossWorkingThread.h"
 
-CSRTActiveSurfaceBossWorkingThread::CSRTActiveSurfaceBossWorkingThread(const ACE_CString& name,IRA::CSecureArea<CSRTActiveSurfaceBossCore>  *param, 
-			const ACS::TimeInterval& responseTime,const ACS::TimeInterval& sleepTime) : ACS::Thread(name,responseTime,sleepTime), m_core(param)
+CSRTActiveSurfaceBossWorkingThread::CSRTActiveSurfaceBossWorkingThread(const ACE_CString& name,CSRTActiveSurfaceBossCore *param,
+			const ACS::TimeInterval& responseTime,const ACS::TimeInterval& sleepTime) : ACS::Thread(name,responseTime,sleepTime), boss(param)
 {
 	AUTO_TRACE("CSRTActiveSurfaceBossWorkingThread::CSRTActiveSurfaceBossWorkingThread()");
 }
@@ -23,10 +23,8 @@ void CSRTActiveSurfaceBossWorkingThread::onStop()
 
 void CSRTActiveSurfaceBossWorkingThread::runLoop()
 {
-    IRA::CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-
     try {
-        resource->workingActiveSurface();
+        boss->workingActiveSurface();
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
 		ex.log(LM_DEBUG);

--- a/SRT/Servers/SRTActiveSurfaceUSDServer/include/usdImpl.h
+++ b/SRT/Servers/SRTActiveSurfaceUSDServer/include/usdImpl.h
@@ -495,6 +495,10 @@ class USDImpl: public CharacteristicComponentImpl,public virtual POA_ActiveSurfa
     	*/
 	bool compCheck(ACSErr::CompletionImpl& );
 
+	int getStatus();
+
+	void updateStatus();
+
     	/** 
     	* flag rappresenting the availability of the module.
     	* It is available if is comunicating. After five times USD doesn't respond, the flag is set to FALSE to inhibit any further activity.


### PR DESCRIPTION
Regarding the servers:
- The USD server now exposes a `updateStatus` method, which only purpose is to ask the hardware for the status, and save it in memory.
- The last retrieved status can be read calling the new `getStatus` method. This prevents a real time call to the hardware, avoiding unnecessary thread starvations.
- Now each `SRTActiveSurfaceSectorThread`, after the initialization of the whole surface, act as a `WatchingThread`, forcing the USDs to update their status by performing a call to the hardware (one USD every 100ms).
- Since the USDs can return their status without socket/hardware latency, the GUI client is now free to ask for the next USD status in a faster way, with a sleep period between each USD of 10ms instead of 100ms like before. In order for the user to see the GUI as more responsive, the USD that is currently being checked becomes yellow during the interrogation, then becomes red/green depending on its retrieved status.
- Removed some unnecessary `SecureAreas` that were preventing the GUI to act as expected when the AS `WorkingThread` is commanding the positions to the USDs. Since the only shared resource that the `SecureAreas` was protecting is a bi-dimentional array (a matrix) of immutable pointers, there is no need for protection (one the instance is initialized, its methods will not change during runtime).

Overall, the components starts the active surface at the same pace as before, but the client, being faster, allows the user to start observing a little earlier than he/she usually does.