### PR TITLE
Fix #433, fixed an issue with a double* that was treated as a normal double

### DIFF
--- a/Common/Servers/Refraction/src/RefractionCore.cpp
+++ b/Common/Servers/Refraction/src/RefractionCore.cpp
@@ -132,7 +132,7 @@ void CRefractionCore::getCorrection(double obsZenithDistance,double waveLen, dou
 
 		slaRefro(obsZenithDistance, hm, tdk, m_pressure, m_humidity, wl, phi, tlr, eps, corZenithDistance);
 	}
-	else corZenithDistance = 0;
+	else *corZenithDistance = 0;
 }
 
 void CRefractionCore::getMeteoParameters()


### PR DESCRIPTION
When assigning a value equal to 0 (when the distance from the zenith is negative), the 0 value was assigned to the pointer, not to the pointer actual value.