### PR TITLE
Fix #437, the SRTActiveSurface updates the USDs positions only when different from the previous one.

### DIFF
--- a/SRT/CDB/alma/AS/Boss/Boss.xml
+++ b/SRT/CDB/alma/AS/Boss/Boss.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
-<SRTActiveSurfaceBoss xmlns="urn:schemas-cosylab-com:SRTActiveSurfaceBoss:1.0" xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" WatchingThreadTime="200000" RepetitionCacheTime="2000000" RepetitionExpireTime="5000000" ElevationUpdateStep="0.1" profile="4">
+<SRTActiveSurfaceBoss xmlns="urn:schemas-cosylab-com:SRTActiveSurfaceBoss:1.0" xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" WatchingThreadTime="200000" RepetitionCacheTime="2000000" RepetitionExpireTime="5000000" profile="0">
 	<status />
 	<enabled />
 	<pprofile />

--- a/SRT/Configuration/CDB/alma/AS/Boss/Boss.xml
+++ b/SRT/Configuration/CDB/alma/AS/Boss/Boss.xml
@@ -386,7 +386,7 @@
    -   Tue Jun 26 14:34:39 UTC 2018 modified by jDAL
    -   Tue Jun 26 14:35:27 UTC 2018 modified by jDAL
 -->
-<SRTActiveSurfaceBoss xmlns="urn:schemas-cosylab-com:SRTActiveSurfaceBoss:1.0" xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" WatchingThreadTime="200000" RepetitionCacheTime="2000000" RepetitionExpireTime="5000000" ElevationUpdateStep="0.1" profile="4">
+<SRTActiveSurfaceBoss xmlns="urn:schemas-cosylab-com:SRTActiveSurfaceBoss:1.0" xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" WatchingThreadTime="200000" RepetitionCacheTime="2000000" RepetitionExpireTime="5000000" profile="4">
 	<status />
 	<enabled />
 	<pprofile />

--- a/SRT/Interfaces/SRTActiveSurfaceInterface/idl/SRTActiveSurfaceBoss.midl
+++ b/SRT/Interfaces/SRTActiveSurfaceInterface/idl/SRTActiveSurfaceBoss.midl
@@ -34,7 +34,8 @@ module ActiveSurface {
         AS_UPDATE,
         AS_CORRECTION,
         AS_MOVE,
-	AS_PROFILE
+        AS_PROFILE,
+        AS_STATUSUPDATE
     };
     ACS_ENUM(TASOneWayAction);
 

--- a/SRT/Servers/SRTActiveSurfaceBoss/config/CDB/schemas/SRTActiveSurfaceBoss.xsd
+++ b/SRT/Servers/SRTActiveSurfaceBoss/config/CDB/schemas/SRTActiveSurfaceBoss.xsd
@@ -37,8 +37,6 @@
 		<xs:attribute name="RepetitionCacheTime" type="xs:unsignedLong" use="required" />
 		<!-- the expire time (microseconds) for logging repetition filter -->
 		<xs:attribute name="RepetitionExpireTime" type="xs:unsignedLong" use="required" />
-		<!-- the elevation step to update the active surface during tracking -->
-		<xs:attribute name="ElevationUpdateStep" type="xs:decimal" use="required" />
         <xs:attribute name="profile" 			type="xs:unsignedByte" 	use="required" />
       </xs:extension>
      </xs:complexContent>

--- a/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossCore.h
+++ b/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossCore.h
@@ -229,9 +229,7 @@ private:
 
     bool m_ASup;
 
-    double m_elevationUpdateStep;
-
-    double m_lastCmdElevation;
+    bool m_setupCompleted;
 };
 
 #endif /*SRTACTIVESURFACEBOSSCORE_H_*/

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossImpl.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossImpl.cpp
@@ -14,414 +14,467 @@ using namespace SimpleParser;
 
 class SRTActiveSurfaceProfile2String {
 public:
-	static char *valToStr(const ActiveSurface::TASProfile& val) {
-		char *c=new char[16];
-		if (val==ActiveSurface::AS_SHAPED) {
-			strcpy(c,"S");
-		}
-		if (val==ActiveSurface::AS_SHAPED_FIXED) {
-			strcpy(c,"SF");
-		}
-		if (val==ActiveSurface::AS_PARABOLIC) {
-			strcpy(c,"P");
-		}
-		if (val==ActiveSurface::AS_PARABOLIC_FIXED) {
-			strcpy(c,"PF");
-		}
-		return c;
-	}
-	static ActiveSurface::TASProfile strToVal(const char* str) throw (ParserErrors::BadTypeFormatExImpl) {
-		IRA::CString strVal(str);
-		strVal.MakeUpper();
-		if (strVal=="S") {
-			return ActiveSurface::AS_SHAPED;
-		}
-		else if (strVal=="SF") {
-			return ActiveSurface::AS_SHAPED_FIXED;
-		}
-		else if (strVal=="P") {
-			return ActiveSurface::AS_PARABOLIC;
-		}
-		else if (strVal=="PF") {
-			return ActiveSurface::AS_PARABOLIC_FIXED;
-		}
-		else {
-			_EXCPT(ParserErrors::BadTypeFormatExImpl,ex,"SRTActiveSurfaceProfile2String::strToVal()");
-			throw ex;
-		}
-	}
+    static char *valToStr(const ActiveSurface::TASProfile& val) {
+        char *c=new char[16];
+        if (val==ActiveSurface::AS_SHAPED) {
+            strcpy(c,"S");
+        }
+        if (val==ActiveSurface::AS_SHAPED_FIXED) {
+            strcpy(c,"SF");
+        }
+        if (val==ActiveSurface::AS_PARABOLIC) {
+            strcpy(c,"P");
+        }
+        if (val==ActiveSurface::AS_PARABOLIC_FIXED) {
+            strcpy(c,"PF");
+        }
+        return c;
+    }
+    static ActiveSurface::TASProfile strToVal(const char* str) throw (ParserErrors::BadTypeFormatExImpl) {
+        IRA::CString strVal(str);
+        strVal.MakeUpper();
+        if (strVal=="S") {
+            return ActiveSurface::AS_SHAPED;
+        }
+        else if (strVal=="SF") {
+            return ActiveSurface::AS_SHAPED_FIXED;
+        }
+        else if (strVal=="P") {
+            return ActiveSurface::AS_PARABOLIC;
+        }
+        else if (strVal=="PF") {
+            return ActiveSurface::AS_PARABOLIC_FIXED;
+        }
+        else {
+            _EXCPT(ParserErrors::BadTypeFormatExImpl,ex,"SRTActiveSurfaceProfile2String::strToVal()");
+            throw ex;
+        }
+    }
 };
 
-SRTActiveSurfaceBossImpl::SRTActiveSurfaceBossImpl(const ACE_CString &CompName, maci::ContainerServices *containerServices) : 
-	CharacteristicComponentImpl(CompName,containerServices),
-	m_pstatus(this),
-	m_penabled(this),
-	m_pprofile(this),
-	m_ptracking(this),
-	m_core(NULL)
-{	
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::SRTActiveSurfaceBossImpl()");
+SRTActiveSurfaceBossImpl::SRTActiveSurfaceBossImpl(const ACE_CString &CompName, maci::ContainerServices *containerServices) :
+    CharacteristicComponentImpl(CompName,containerServices),
+    m_pstatus(this),
+    m_penabled(this),
+    m_pprofile(this),
+    m_ptracking(this),
+    m_core(NULL)
+{
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::SRTActiveSurfaceBossImpl()");
 }
 
 SRTActiveSurfaceBossImpl::~SRTActiveSurfaceBossImpl()
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::~SRTActiveSurfaceBossImpl()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::~SRTActiveSurfaceBossImpl()");
 }
 
 void SRTActiveSurfaceBossImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::initialize()");
-    	cs = getContainerServices();
-    	//CSRTActiveSurfaceBossCore *boss;
-    	ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::initialize()",(LM_INFO,"COMPSTATE_INITIALIZING"));
-	try {
-		boss=(CSRTActiveSurfaceBossCore *)new CSRTActiveSurfaceBossCore(getContainerServices(),this);
-		m_core=new IRA::CSecureArea<CSRTActiveSurfaceBossCore>(boss);
-        	m_pstatus=new ROEnumImpl<ACS_ENUM_T(Management::TSystemStatus),POA_Management::ROTSystemStatus>
-		  (getContainerServices()->getName()+":status",getComponent(),new SRTActiveSurfaceBossImplDevIOStatus(m_core),true);	
-		m_penabled=new ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean>
-		  (getContainerServices()->getName()+":enabled",getComponent(),new SRTActiveSurfaceBossImplDevIOEnable(m_core),true);
-		m_pprofile=new ROEnumImpl<ACS_ENUM_T(ActiveSurface::TASProfile),POA_ActiveSurface::ROTASProfile>
-		  (getContainerServices()->getName()+":pprofile",getComponent(),new SRTActiveSurfaceBossImplDevIOProfile(m_core),true);	
-		m_ptracking=new ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean>
-		  (getContainerServices()->getName()+":tracking",getComponent(),new SRTActiveSurfaceBossImplDevIOTracking(m_core),true);
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::initialize()");
+    cs = getContainerServices();
+    //CSRTActiveSurfaceBossCore *boss;
+    ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::initialize()",(LM_INFO,"COMPSTATE_INITIALIZING"));
+    try {
+        boss=(CSRTActiveSurfaceBossCore *)new CSRTActiveSurfaceBossCore(getContainerServices(),this);
+        m_core=new IRA::CSecureArea<CSRTActiveSurfaceBossCore>(boss);
+        m_pstatus=new ROEnumImpl<ACS_ENUM_T(Management::TSystemStatus),POA_Management::ROTSystemStatus>
+          (getContainerServices()->getName()+":status",getComponent(),new SRTActiveSurfaceBossImplDevIOStatus(m_core),true);
+        m_penabled=new ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean>
+          (getContainerServices()->getName()+":enabled",getComponent(),new SRTActiveSurfaceBossImplDevIOEnable(m_core),true);
+        m_pprofile=new ROEnumImpl<ACS_ENUM_T(ActiveSurface::TASProfile),POA_ActiveSurface::ROTASProfile>
+          (getContainerServices()->getName()+":pprofile",getComponent(),new SRTActiveSurfaceBossImplDevIOProfile(m_core),true);
+        m_ptracking=new ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean>
+          (getContainerServices()->getName()+":tracking",getComponent(),new SRTActiveSurfaceBossImplDevIOTracking(m_core),true);
 
-        	// create the parser for command line execution
-		m_parser =  new SimpleParser::CParser<CSRTActiveSurfaceBossCore>(boss,10);
-    	}
-    	catch (std::bad_alloc& ex) {
-		_EXCPT(ComponentErrors::MemoryAllocationExImpl,dummy,"SRTActiveSurfaceBossImpl::initialize()");
-		throw dummy;
-	}
+        // create the parser for command line execution
+        m_parser =  new SimpleParser::CParser<CSRTActiveSurfaceBossCore>(boss,10);
+    }
+    catch (std::bad_alloc& ex) {
+        _EXCPT(ComponentErrors::MemoryAllocationExImpl,dummy,"SRTActiveSurfaceBossImpl::initialize()");
+        throw dummy;
+    }
     boss->initialize();
-	try {
-		m_workingThread=getContainerServices()->getThreadManager()->create<CSRTActiveSurfaceBossWorkingThread,CSRTActiveSurfaceBossCore *>
-		  ("SRTACTIVESURFACEBOSSWORKER",boss);
-	}
-	catch (acsthreadErrType::acsthreadErrTypeExImpl& ex) {
-		_ADD_BACKTRACE(ComponentErrors::ThreadErrorExImpl,_dummy,ex,"SRTActiveSurfaceBossImpl::initialize()");
-		throw _dummy;
-	}
-	catch (...) {
-		_THROW_EXCPT(ComponentErrors::UnexpectedExImpl,"SRTActiveSurfaceBossImpl::initialize()");
-	}
+    try {
+        m_workingThread=getContainerServices()->getThreadManager()->create<CSRTActiveSurfaceBossWorkingThread,CSRTActiveSurfaceBossCore *>
+          ("SRTACTIVESURFACEBOSSWORKER",boss);
+    }
+    catch (acsthreadErrType::acsthreadErrTypeExImpl& ex) {
+        _ADD_BACKTRACE(ComponentErrors::ThreadErrorExImpl,_dummy,ex,"SRTActiveSurfaceBossImpl::initialize()");
+        throw _dummy;
+    }
+    catch (...) {
+        _THROW_EXCPT(ComponentErrors::UnexpectedExImpl,"SRTActiveSurfaceBossImpl::initialize()");
+    }
 
-	for(int sector = 0; sector < SECTORS; sector++)
-	{
-		std::stringstream threadName;
-		threadName << "SRTACTIVESURFACEBOSSSECTOR";
-		threadName << sector+1;
-		try {
-			CSRTActiveSurfaceBossSectorThread* sectorThread = getContainerServices()->getThreadManager()->create<CSRTActiveSurfaceBossSectorThread,CSRTActiveSurfaceBossCore *> (threadName.str().c_str(), boss);
-			sectorThread->prepare(sector);
-			m_sectorThread.push_back(sectorThread);
-		}
-		catch (acsthreadErrType::acsthreadErrTypeExImpl& ex) {
-			_ADD_BACKTRACE(ComponentErrors::ThreadErrorExImpl,_dummy,ex,"SRTActiveSurfaceBossImpl::initialize()");
-			throw _dummy;
-		}
-		catch (...) {
-			_THROW_EXCPT(ComponentErrors::UnexpectedExImpl,"SRTActiveSurfaceBossImpl::initialize()");
-		}
-	}
+    for(int sector = 0; sector < SECTORS; sector++)
+    {
+        std::stringstream threadName;
+        threadName << "SRTACTIVESURFACEBOSSSECTOR";
+        threadName << sector+1;
+        try {
+            CSRTActiveSurfaceBossSectorThread* sectorThread = getContainerServices()->getThreadManager()->create<CSRTActiveSurfaceBossSectorThread,CSRTActiveSurfaceBossCore *> (threadName.str().c_str(), boss);
+            sectorThread->prepare(sector);
+            m_sectorThread.push_back(sectorThread);
+        }
+        catch (acsthreadErrType::acsthreadErrTypeExImpl& ex) {
+            _ADD_BACKTRACE(ComponentErrors::ThreadErrorExImpl,_dummy,ex,"SRTActiveSurfaceBossImpl::initialize()");
+            throw _dummy;
+        }
+        catch (...) {
+            _THROW_EXCPT(ComponentErrors::UnexpectedExImpl,"SRTActiveSurfaceBossImpl::initialize()");
+        }
+    }
 
-	if (CIRATools::getDBValue(cs,"profile",(long&)m_profile))
-	{
-		ACS_SHORT_LOG((LM_INFO,"SRTActiveSurfaceBoss: CDB %d profile parameter read", m_profile));
-		boss->m_profile = m_profile;
-	}
-	else
-	{
-		ACS_LOG(LM_SOURCE_INFO,"SRTActiveSurfaceBossImpl:initialize()",(LM_ERROR,"Error reading CDB!"));
-		ASErrors::CDBAccessErrorExImpl exImpl(__FILE__,__LINE__,"USDImpl::initialize() - Error reading CDB parameters");
-		throw acsErrTypeLifeCycle::LifeCycleExImpl(exImpl,__FILE__,__LINE__,"USDImpl::initialize()");
-	}
+    if (CIRATools::getDBValue(cs,"profile",(long&)m_profile))
+    {
+        ACS_SHORT_LOG((LM_INFO,"SRTActiveSurfaceBoss: CDB %d profile parameter read", m_profile));
+        boss->m_profile = m_profile;
+    }
+    else
+    {
+        ACS_LOG(LM_SOURCE_INFO,"SRTActiveSurfaceBossImpl:initialize()",(LM_ERROR,"Error reading CDB!"));
+        ASErrors::CDBAccessErrorExImpl exImpl(__FILE__,__LINE__,"USDImpl::initialize() - Error reading CDB parameters");
+        throw acsErrTypeLifeCycle::LifeCycleExImpl(exImpl,__FILE__,__LINE__,"USDImpl::initialize()");
+    }
 
-    	// configure the parser.....
-    	m_parser->add("asSetup",new function1<CSRTActiveSurfaceBossCore,non_constant,void_type,I<enum_type<SRTActiveSurfaceProfile2String,ActiveSurface::TASProfile> > >(boss,&CSRTActiveSurfaceBossCore::setProfile),1);
-	m_parser->add("asOn",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asOn),0);
-	m_parser->add("asOff",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asOff),0);
-	m_parser->add("asPark",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asPark),0);
+    // configure the parser.....
+    m_parser->add("asSetup",new function1<CSRTActiveSurfaceBossCore,non_constant,void_type,I<enum_type<SRTActiveSurfaceProfile2String,ActiveSurface::TASProfile> > >(boss,&CSRTActiveSurfaceBossCore::setProfile),1);
+    m_parser->add("asOn",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asOn),0);
+    m_parser->add("asOff",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asOff),0);
+    m_parser->add("asPark",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asPark),0);
 
     ACS_LOG(LM_FULL_INFO, "SRTActiveSurfaceBossImpl::initialize()", (LM_INFO,"COMPSTATE_INITIALIZED"));
 }
 
 void SRTActiveSurfaceBossImpl::execute() throw (ACSErr::ACSbaseExImpl)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::execute()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::execute()");
 
-	//CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore>  core=m_core->Get();
-    	//core->m_profile = m_profile;
+    try {
+        boss->execute();
+    }
+    catch (ACSErr::ACSbaseExImpl& E) {
+        _ADD_BACKTRACE(ComponentErrors::InitializationProblemExImpl,_dummy,E,"SRTActiveSurfaceBossImpl::execute()");
+        throw _dummy;
+    }
 
-    	try {
-		//core->execute();
-		boss->execute();
-	}
-	catch (ACSErr::ACSbaseExImpl& E) {
-		_ADD_BACKTRACE(ComponentErrors::InitializationProblemExImpl,_dummy,E,"SRTActiveSurfaceBossImpl::execute()");
-		throw _dummy;
-	}
-	//starts the loop working thread....
-	m_workingThread->resume();
-	m_workingThread->setSleepTime(LOOPWORKINGTIME);
+    for(unsigned int i = 0; i < m_sectorThread.size(); i++)
+    {
+        m_sectorThread[i]->resume();
+    }
 
-	for(unsigned int i = 0; i < m_sectorThread.size(); i++)
-	{
-		m_sectorThread[i]->resume();
-	}
+    //starts the loop working thread....
+    m_workingThread->resume();
+    m_workingThread->setSleepTime(LOOPWORKINGTIME);
 
-	ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::execute()",(LM_INFO,"SRTActiveSurfaceBossImpl::COMPSTATE_OPERATIONAL"));
+    ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::execute()",(LM_INFO,"SRTActiveSurfaceBossImpl::COMPSTATE_OPERATIONAL"));
 }
 
 void SRTActiveSurfaceBossImpl::cleanUp()
 {
     AUTO_TRACE("SRTActiveSurfaceBossImpl::cleanUp()");
-   	if (m_workingThread!=NULL)
+    if (m_workingThread!=NULL)
     {
         m_workingThread->suspend();
-    	getContainerServices()->getThreadManager()->destroy(m_workingThread);
+        getContainerServices()->getThreadManager()->destroy(m_workingThread);
     }
     for(unsigned int i = 0; i < m_sectorThread.size(); i++)
     {
         if(m_sectorThread[i] != NULL)
         {
             m_sectorThread[i]->suspend();
-    	    getContainerServices()->getThreadManager()->destroy(m_sectorThread[i]);
+            getContainerServices()->getThreadManager()->destroy(m_sectorThread[i]);
         }
     }
     ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::cleanUp()",(LM_INFO,"SRTActiveSurfaceBossImpl::THREADS_TERMINATED"));
     if (m_parser!=NULL) delete m_parser;
     ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::cleanUp()",(LM_INFO,"SRTActiveSurfaceBossImpl::PARSER_FREED"));
     CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> core = m_core->Get();
-	core->cleanUp();
+    core->cleanUp();
     ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::cleanUp()",(LM_INFO,"SRTActiveSurfaceBossImpl::BOSS_CORE_FREED"));
     CharacteristicComponentImpl::cleanUp();
 }
 
 void SRTActiveSurfaceBossImpl::aboutToAbort()
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::aboutToAbort()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::aboutToAbort()");
     if (m_workingThread!=NULL)
     {
         m_workingThread->suspend();
         getContainerServices()->getThreadManager()->destroy(m_workingThread);
     }
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore>  core=m_core->Get(); 
-	core->cleanUp();
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore>  core=m_core->Get();
+    core->cleanUp();
     if (m_parser!=NULL) delete m_parser;
 }
 
 void SRTActiveSurfaceBossImpl::stop (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::stop()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::stop()");
 
-    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
+
     try {
-        resource->onewayAction(ActiveSurface::AS_STOP, circle, actuator, radius, 0, 0, 0, m_profile);
+        boss->onewayAction(ActiveSurface::AS_STOP, circle, actuator, radius, 0, 0, 0, m_profile);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::setup (const char *config) throw (CORBA::SystemException, ManagementErrors::ConfigurationErrorEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::setup()");
-	IRA::CString strVal(config);
-	strVal.MakeUpper();
-	if (strVal=="S") {
-		setProfile(ActiveSurface::AS_SHAPED);
-	}
-	else if (strVal=="SF") {
-		setProfile(ActiveSurface::AS_SHAPED_FIXED);
-	}
-	else if (strVal=="P") {
-		setProfile(ActiveSurface::AS_PARABOLIC);
-	}
-	else if (strVal=="PF") {
-		setProfile(ActiveSurface::AS_PARABOLIC_FIXED);
-	}
-	else {
-		_EXCPT(ManagementErrors::ConfigurationErrorExImpl,ex,"SRTActiveSurfaceBossImpl::setup()");
-		throw ex.getConfigurationErrorEx();
-	}
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::setup()");
+    IRA::CString strVal(config);
+    strVal.MakeUpper();
+    if (strVal=="S") {
+        setProfile(ActiveSurface::AS_SHAPED);
+    }
+    else if (strVal=="SF") {
+        setProfile(ActiveSurface::AS_SHAPED_FIXED);
+    }
+    else if (strVal=="P") {
+        setProfile(ActiveSurface::AS_PARABOLIC);
+    }
+    else if (strVal=="PF") {
+        setProfile(ActiveSurface::AS_PARABOLIC_FIXED);
+    }
+    else {
+        _EXCPT(ManagementErrors::ConfigurationErrorExImpl,ex,"SRTActiveSurfaceBossImpl::setup()");
+        throw ex.getConfigurationErrorEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::park () throw (CORBA::SystemException, ManagementErrors::ParkingErrorEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::park()");
-    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::park()");
+
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
+
     try {
-       	resource->asPark();
+        boss->asPark();
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		_EXCPT(ManagementErrors::ParkingErrorExImpl,ex,"SRTActiveSurfaceBossImpl::park()");
-		throw ex.getParkingErrorEx();
-	}
-	resource->m_tracking = false;
+        _EXCPT(ManagementErrors::ParkingErrorExImpl,ex,"SRTActiveSurfaceBossImpl::park()");
+        throw ex.getParkingErrorEx();
+    }
+    boss->m_tracking = false;
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::stow (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::stow()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::stow()");
 
-    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
+
     try {
-        resource->onewayAction(ActiveSurface::AS_STOW, circle, actuator, radius, 0, 0, 0, m_profile);
+        boss->onewayAction(ActiveSurface::AS_STOW, circle, actuator, radius, 0, 0, 0, m_profile);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::refPos (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::refPos()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::refPos()");
 
-    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
+
     try {
-        resource->onewayAction(ActiveSurface::AS_REFPOS, circle, actuator, radius, 0, 0, 0, m_profile);
+        boss->onewayAction(ActiveSurface::AS_REFPOS, circle, actuator, radius, 0, 0, 0, m_profile);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::update (CORBA::Double elevation) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::update()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::update()");
 
-    	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
 
-	try {
-        	resource->onewayAction(ActiveSurface::AS_UPDATE, 0, 0, 0, elevation, 0, 0, m_profile);
-    	}
-    	catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    try {
+        boss->onewayAction(ActiveSurface::AS_UPDATE, 0, 0, 0, elevation, 0, 0, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex) {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::up (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::up()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::up()");
 
-    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
+
     try {
-        resource->onewayAction(ActiveSurface::AS_UP, circle, actuator, radius, 0, 0, 0, m_profile);
+        boss->onewayAction(ActiveSurface::AS_UP, circle, actuator, radius, 0, 0, 0, m_profile);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::down (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::down()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::down()");
 
-    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
+
     try {
-        resource->onewayAction(ActiveSurface::AS_DOWN, circle, actuator, radius, 0, 0, 0, m_profile);
+        boss->onewayAction(ActiveSurface::AS_DOWN, circle, actuator, radius, 0, 0, 0, m_profile);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::bottom (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::bottom()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::bottom()");
 
-    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
+
     try {
-        resource->onewayAction(ActiveSurface::AS_BOTTOM, circle, actuator, radius, 0, 0, 0, m_profile);
+        boss->onewayAction(ActiveSurface::AS_BOTTOM, circle, actuator, radius, 0, 0, 0, m_profile);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::top (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::top()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::top()");
 
-    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
+
     try {
-        resource->onewayAction(ActiveSurface::AS_TOP, circle, actuator, radius, 0, 0, 0, m_profile);
+        boss->onewayAction(ActiveSurface::AS_TOP, circle, actuator, radius, 0, 0, 0, m_profile);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::move (CORBA::Long circle,  CORBA::Long actuator,  CORBA::Long radius, CORBA::Long incr) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::move()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::move()");
 
-    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
+
     try {
-        resource->onewayAction(ActiveSurface::AS_MOVE, circle, actuator, radius, 0, 0, incr, m_profile);
+        boss->onewayAction(ActiveSurface::AS_MOVE, circle, actuator, radius, 0, 0, incr, m_profile);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::correction (CORBA::Long circle,  CORBA::Long actuator,  CORBA::Long radius, CORBA::Double correction) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::correction()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::correction()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try {
-		resource->onewayAction(ActiveSurface::AS_CORRECTION, circle, actuator, radius, 0, correction, 0, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    if (m_workingThread!=NULL)
+        m_workingThread->suspend();
+
+    try {
+        boss->onewayAction(ActiveSurface::AS_CORRECTION, circle, actuator, radius, 0, correction, 0, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex) {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+
+    if (m_workingThread!=NULL)
+        m_workingThread->resume();
 }
 
 void SRTActiveSurfaceBossImpl::reset (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::reset()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::reset()");
 
     CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
     try {
         resource->reset(circle, actuator, radius);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::setProfile (ActiveSurface::TASProfile newProfile) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::setProfile()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::setProfile()");
 
-	m_profile = newProfile;
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try {
-		resource->setProfile(m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    m_profile = newProfile;
+
+    try {
+        resource->setProfile(m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex) {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::usdStatus4GUIClient (CORBA::Long circle, CORBA::Long actuator, CORBA::Long_out status) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::usdStatus4GUIClient()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::usdStatus4GUIClient()");
 
     try {
         boss->usdStatus4GUIClient(circle, actuator, status);
@@ -434,7 +487,7 @@ void SRTActiveSurfaceBossImpl::usdStatus4GUIClient (CORBA::Long circle, CORBA::L
 
 void SRTActiveSurfaceBossImpl::setActuator (CORBA::Long circle, CORBA::Long actuator, CORBA::Long_out actPos, CORBA::Long_out cmdPos, CORBA::Long_out Fmin, CORBA::Long_out Fmax, CORBA::Long_out acc, CORBA::Long_out delay) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::setActuator");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::setActuator");
 
     long int act, cmd, fmin, fmax, ac, del;
 
@@ -443,9 +496,9 @@ void SRTActiveSurfaceBossImpl::setActuator (CORBA::Long circle, CORBA::Long actu
         resource->setActuator(circle, actuator, act, cmd, fmin, fmax, ac, del);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
     actPos = (CORBA::Long)act;
     cmdPos = (CORBA::Long)cmd;
     Fmin = (CORBA::Long)fmin;
@@ -457,101 +510,103 @@ void SRTActiveSurfaceBossImpl::setActuator (CORBA::Long circle, CORBA::Long actu
 
 void SRTActiveSurfaceBossImpl::calibrate (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::calibrate()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::calibrate()");
 
     CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
     try {
         resource->calibrate(circle, actuator, radius);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::calVer (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::calibration verification()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::calibration verification()");
 
     CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
     try {
         resource->calVer(circle, actuator, radius);
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 
 void SRTActiveSurfaceBossImpl::recoverUSD (CORBA::Long circle, CORBA::Long actuator) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::recoverUSD()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::recoverUSD()");
 
     CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
     try {
         //resource->recoverUSD(circle, actuator); TBC!!
     }
     catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::asOn() throw (CORBA::SystemException)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::asOn()");
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try {
-		resource->asOn();
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::asOn()");
+
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try {
+        resource->asOn();
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex) {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::asOff() throw (CORBA::SystemException)
 {
     AUTO_TRACE("SRTActiveSurfaceBossImpl::asOff()");
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try {
-		resource->asOff();
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex) {
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try {
+        resource->asOff();
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex) {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 CORBA::Boolean SRTActiveSurfaceBossImpl::command(const char *cmd,CORBA::String_out answer) throw (CORBA::SystemException)
 //char *SRTActiveSurfaceBossImpl::command(const char *cmd) throw (CORBA::SystemException, ManagementErrors::CommandLineErrorEx)
 {
-	AUTO_TRACE("AntennaBossImpl::command()");
-	IRA::CString out;
-	bool res;
-	//IRA::CString in;
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	//in=IRA::CString(cmd);
-	try {
-		m_parser->run(cmd,out);
-		res = true;
-	}
-	catch (ParserErrors::ParserErrorsExImpl &ex) {
-		/*_ADD_BACKTRACE(ManagementErrors::CommandLineErrorExImpl,impl,ex,"SRTActiveSurfaceBossImpl::command()");
-		impl.setCommand(cmd);
-		impl.setErrorMessage((const char *)out);
-		impl.log(LM_DEBUG);
-		throw impl.getCommandLineErrorEx();*/
-		res = false;
-	}
-	catch (ACSErr::ACSbaseExImpl& ex) {
-		ex.log(LM_ERROR); // the errors resulting from the execution are logged here as stated in the documentation of CommandInterpreter interface, while the parser errors are never logged.
-		res=false;
-	}
-	answer=CORBA::string_dup((const char *)out);
-	return res;
-	//return CORBA::string_dup((const char *)out);
+    AUTO_TRACE("AntennaBossImpl::command()");
+    IRA::CString out;
+    bool res;
+    //IRA::CString in;
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    //in=IRA::CString(cmd);
+    try {
+        m_parser->run(cmd,out);
+        res = true;
+    }
+    catch (ParserErrors::ParserErrorsExImpl &ex) {
+        /*_ADD_BACKTRACE(ManagementErrors::CommandLineErrorExImpl,impl,ex,"SRTActiveSurfaceBossImpl::command()");
+        impl.setCommand(cmd);
+        impl.setErrorMessage((const char *)out);
+        impl.log(LM_DEBUG);
+        throw impl.getCommandLineErrorEx();*/
+        res = false;
+    }
+    catch (ACSErr::ACSbaseExImpl& ex) {
+        ex.log(LM_ERROR); // the errors resulting from the execution are logged here as stated in the documentation of CommandInterpreter interface, while the parser errors are never logged.
+        res=false;
+    }
+    answer=CORBA::string_dup((const char *)out);
+    return res;
+    //return CORBA::string_dup((const char *)out);
 }
 
 _PROPERTY_REFERENCE_CPP(SRTActiveSurfaceBossImpl,Management::ROTSystemStatus,m_pstatus,status);

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossSectorThread.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossSectorThread.cpp
@@ -31,7 +31,7 @@ void CSRTActiveSurfaceBossSectorThread::prepare(int sector)
     if(m_ready) return;
     m_ready = true;
 
-    //for setup phase we set the sleep time to 1ms in order to be fast
+    //we set the sleep time to 1ms in order to be fast
     this->setSleepTime(10000);
 
     m_sector = sector;
@@ -77,8 +77,7 @@ void CSRTActiveSurfaceBossSectorThread::runLoop()
     m_index++;
     if(m_index == m_usd_count)
     {
-        this->setSleepTime(1000000); //setup phase ended, set the sleep time at 100ms
         boss->sectorSetupCompleted(m_sector);
-        m_index = 0;
+        this->suspend();
     }
 }

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossWorkingThread.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossWorkingThread.cpp
@@ -18,15 +18,15 @@ void CSRTActiveSurfaceBossWorkingThread::onStart()
 
 void CSRTActiveSurfaceBossWorkingThread::onStop()
 {
-	 AUTO_TRACE("CSRTActiveSurfaceBossWorkingThread::onStop()");
+	AUTO_TRACE("CSRTActiveSurfaceBossWorkingThread::onStop()");
 }
 
 void CSRTActiveSurfaceBossWorkingThread::runLoop()
 {
-    try {
-        boss->workingActiveSurface();
-    }
-    catch (ComponentErrors::ComponentErrorsExImpl& ex) {
+	try {
+		boss->workingActiveSurface();
+	}
+	catch (ComponentErrors::ComponentErrorsExImpl& ex) {
 		ex.log(LM_DEBUG);
-    }
+	}
 }

--- a/SRT/Servers/SRTActiveSurfaceUSDServer/include/usdImpl.h
+++ b/SRT/Servers/SRTActiveSurfaceUSDServer/include/usdImpl.h
@@ -567,9 +567,15 @@ class USDImpl: public CharacteristicComponentImpl,public virtual POA_ActiveSurfa
 	* threshold between actual and updated position
 	*/
 	double *actuatorsCorrections;
+	double *elevations;
 	int parPositions;
 	double deltaEL;
 	int threshold;
+
+	/**
+	* last commanded position (steps)
+	*/
+	int m_lastCmdStep;
 
 	/**
 	* camma len and camma pos in degrees

--- a/SRT/Servers/SRTActiveSurfaceUSDServer/src/usdImpl.cpp
+++ b/SRT/Servers/SRTActiveSurfaceUSDServer/src/usdImpl.cpp
@@ -38,7 +38,8 @@ USDImpl::USDImpl(const ACE_CString& CompName, maci::ContainerServices* container
     	m_userOffset_sp(this)	
 { 
 	ACS_SHORT_LOG((LM_INFO,"::USDImpl::USDImpl: constructor;Constructor!"));
-    actuatorsCorrections = NULL;
+	actuatorsCorrections = NULL;
+	elevations = NULL;
 }
 
 void USDImpl::initialize() throw (ACSErr::ACSbaseExImpl)
@@ -65,6 +66,7 @@ void USDImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 		ASErrors::CDBAccessErrorExImpl exImpl(__FILE__,__LINE__,"USDImpl::initialize() - Error reading CDB parameters");
 		throw acsErrTypeLifeCycle::LifeCycleExImpl(exImpl,__FILE__,__LINE__,"USDImpl::initialize()");
 	}
+	m_lastCmdStep = 30000; // a value outside of range -21000/+21000 will never be commanded, so the next commanded position will SURELY be different
 	m_step2deg=(double)(360./m_step_giro);
 	m_step_res=(double)(1./pow(2,m_rs));
 	m_top=-m_zeroRef;
@@ -257,10 +259,15 @@ void USDImpl::cleanUp()
 		 m_pLan = ActiveSurface::lan::_nil();
 	}
 
-    if(actuatorsCorrections != NULL)
-    {
-        delete [] actuatorsCorrections;
-    }
+	if(actuatorsCorrections != NULL)
+	{
+		delete [] actuatorsCorrections;
+	}
+
+	if(elevations != NULL)
+	{
+		delete [] elevations;
+	}
 }
 
  
@@ -280,10 +287,15 @@ void USDImpl::aboutToAbort()
 	//m_pLan = MOD_LAN::lan::_nil();
 	m_pLan = ActiveSurface::lan::_nil();
 
-    if(actuatorsCorrections != NULL)
-    {
-        delete [] actuatorsCorrections;
-    }
+	if(actuatorsCorrections != NULL)
+	{
+		delete [] actuatorsCorrections;
+	}
+
+	if(elevations != NULL)
+	{
+		delete [] elevations;
+	}
 }
 
 void USDImpl::reset() 	throw (CORBA::SystemException,ASErrors::ASErrorsEx)
@@ -547,93 +559,56 @@ void USDImpl:: writeCalibration(CORBA::Double_out cammaLenD, CORBA::Double_out c
 
 void USDImpl::posTable (const ACS::doubleSeq& theActuatorsCorrections, CORBA::Long theParPositions, CORBA::Double theDeltaEL, CORBA::Long theThreshold)
 {
-	int s;
-
 	parPositions = theParPositions;
 	deltaEL = theDeltaEL;
 	threshold = theThreshold;
 
+	if (actuatorsCorrections != NULL)
+		delete [] actuatorsCorrections;
 	actuatorsCorrections = new double [parPositions];
-	//printf ("corrections = ");
-	//printf ("threshold in posTable = %d\n", threshold);
-	for (s = 0; s < parPositions; s++) {
+	for (int s = 0; s < parPositions; s++)
 		actuatorsCorrections [s] = theActuatorsCorrections[s];
-	//	printf ("%f ", actuatorsCorrections [s]);
-	}
-	//printf("\n");
+
+	if (elevations != NULL)
+		delete [] elevations;
+	elevations = new double [parPositions-1];
+	for (int k = 0; k < parPositions-1; k++)
+		elevations[k] = (k+1)*deltaEL;
 }
 
 void USDImpl::update (CORBA::Double elevation) throw (CORBA::SystemException,ASErrors::ASErrorsEx)
 {
 	double updatePosMM = 0.0;
-	long updatePos;//, actpos, diffPos;
-	int k;
-	double elevations[parPositions-1];
-	bool running;
-
+	long updatePos;
 	try {
-		for (k = 0; k < parPositions-1; k++)
-			elevations [k] = (k+1)*deltaEL;
-		if (m_profile == 1 || m_profile == 3) { // FIXED positions
-			if (m_profile == 1) { // SHAPED FIXED
-				//printf("shaped fixed\n");
-				updatePosMM = actuatorsCorrections[parPositions-5]; // 45
-			}
-			if (m_profile == 3) { // PARABOLIC FIXED
-				//printf("parabolic fixed\n");
-				updatePosMM = actuatorsCorrections[parPositions-5] + actuatorsCorrections[parPositions-1]; // 45 + P
-			}
-			//printf("parabFix = %f,",actuatorsCorrections[parPositions-1]);
-			//updatePosMM = actuatorsCorrections[parPositions-1];
-		//	updatePos = (CORBA::Long)(updatePosMM*MM2STEP);
-			//printf("upPosStep = %ld\n",updatePos);
-		//	_SET_PROP(cmdPos,updatePos,"usdImpl::calibrate()")
-		}
-		else { // SHAPED
-			//printf("shaped\n");
-			if (elevation <= 15.0) {
+		if (m_profile == 1) // SHAPED FIXED
+			updatePosMM = actuatorsCorrections[parPositions-5]; // 45
+		else if (m_profile == 3) // PARABOLIC FIXED
+			updatePosMM = actuatorsCorrections[parPositions-5] + actuatorsCorrections[parPositions-1]; // 45 + P
+		else // SHAPED
+		{
+			if (elevation <= 15.0)
 				updatePosMM = actuatorsCorrections[0];
-				// printf("elevation = %f, upPosMM = %f,",elevation,updatePosMM);
-			}
-			else if (elevation >= 90 ) {
+			else if (elevation >= 90 )
 				updatePosMM = actuatorsCorrections[parPositions-2];
-				// printf("elevation = %f, upPosMM = %f,",elevation,updatePosMM);
-			}
-			else {
-				k = (int)(floor(elevation/deltaEL));
+			else
+			{
+				int k = (int)(floor(elevation/deltaEL));
 				updatePosMM = ((elevation-elevations[k-1])/deltaEL)*(actuatorsCorrections[k]-actuatorsCorrections[k-1])+actuatorsCorrections[k-1];
-				// printf("elevation = %f, upPosMM = %f,",elevation,updatePosMM);
 			}
-			if (m_profile == 2) { // SHAPED + PARABOLIC
-			//	printf("parabolic\n");
+			if (m_profile == 2) // SHAPED + PARABOLIC
 				updatePosMM += actuatorsCorrections[parPositions-1];
-				// printf("elevation = %f, upPosMM parab = %f,",elevation,updatePosMM);
-			}
-		//	updatePos = (CORBA::Long)(updatePosMM*MM2STEP);
-			// printf("upPosStep = %ld\n",updatePos);
-			// _GET_PROP(actPos,actpos,"usdImpl::update()")
-			// printf("actpos = %ld\n", actpos);
-			// diffPos = labs(actpos-updatePos);
-			// printf("threshold = %d\n", threshold);
-			// if (diffPos >= threshold) {
-			// printf("diff >= threshold: %ld\n", diffPos);
-			// updateStatus();
-			//running = m_status&MRUN;
-			//if (running == false)
-			//	_SET_PROP(cmdPos,updatePos,"usdImpl::update()")
-			// }
 		}
 		updatePos = (CORBA::Long)(updatePosMM*MM2STEP);
-        if (updatePos > 21000)
-            updatePos = 21000;
-        if (updatePos < -21000)
-            updatePos = -21000;
-		//printf("upPosStep = %ld\n",updatePos);
-		updateStatus();
-		running = m_status&MRUN;
-		if (running == false)
-			_SET_PROP(cmdPos,updatePos,"usdImpl::update()")
-		//_SET_PROP(cmdPos,updatePos,"usdImpl::calibrate()")
+		if (updatePos > 21000)
+			updatePos = 21000;
+		if (updatePos < -21000)
+			updatePos = -21000;
+		bool running = m_status&MRUN;
+		if (updatePos == m_lastCmdStep || running)
+			return;
+		_SET_PROP(cmdPos,updatePos,"usdImpl::update()")
+		m_lastCmdStep = updatePos;
 	}
 	_CATCH_EXCP_THROW_EX(CORBA::SystemException,corbaError,"::usdImpl::update()",m_addr)	// for CORBA
 	_CATCH_EXCP_THROW_EX(ASErrors::DevIOErrorEx,DevIOError,"::usdImpl::update()",m_addr)	// for _GET_PROP


### PR DESCRIPTION
For every USD, a check on the commanded `step` of the actuator is made before trying to send the new position. If the new position is no different than the previous one, no command is sent to avoid slowing down the LAN with unnecessary commands.