### PR TITLE
Issue #447, the SRT AS GUI now takes into account the elapsed time each iteration

### DIFF
--- a/SRT/Clients/SRTActiveSurfaceGUIClient/src/SRTActiveSurfaceCore.cpp
+++ b/SRT/Clients/SRTActiveSurfaceGUIClient/src/SRTActiveSurfaceCore.cpp
@@ -224,9 +224,7 @@ void SRTActiveSurfaceCore::run(void)
         int elapsed = (t1 - t0) / 10; //Time is expressed in hundreds of nanoseconds, we convert it to microseconds in order to use it with the Wait function
 
         if(elapsed < 100000)
-        {
-            CIRATools::Wait(std::max(0, 100000 - elapsed));
-        }
+            CIRATools::Wait(100000 - elapsed);
     } // end of while
 }
 


### PR DESCRIPTION
It means that after the iteration is completed it goes to sleep for an amount of milliseconds equal to 100ms minus the elapsed time since the start of the current iteration. This will result in a sleep time of 0 whenever the elapsed time for the requests to the AS boss is greater or equal to 100ms. The GUI is still lagging though, so this does not fix the issue completely.