### PR TITLE
Fix issue #452: Total power backend now applies correct timestamp (re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,29 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/
 
-## [discos1.0.2] 01-08-2019
-### Added
-### Changed
-
-    issue #423 - The SRT Active Surface now is monitored by 8 threads (the same threads that perform its initialization). The USDs statuses are updated inside these threads (roughly once every 15 seconds). The `usdStatus4GUI` method now returns the last read status of the given USD instead of interrogating the hardware in real time. The changes brought to the SRT Active Surface allowed its GUI to be improved. Since now it asks for the last known status of every USD without interrogating the hardware in real time, the thread is able to go from USD to USD in 10ms instead of 100ms. A complete loop of the USDs now lasts less than 15 seconds, the UI therefore appears much more responsive to the users, allowing them to send commands to the AS earlier than before (the startup time of the whole AS is approximately the same, but the UI catches up more quickly when the ASBoss is ready).
-
-    issue #404 - Minor fixes were introduced in the SRT test CDB.
-
-    feature - The TimeTaggedCircularArray class is now thread safe.
-
-### Fixed
-
-    issue #431 - The AntennaBoss WatchingThread is now free to read updated values from the mount component without starving. This was tested in the SRT environment with the ACU simulator. No tests were carried on in the Medicina/Noto environments, but due to the different socket nature of the ACU, this should not be an issue. In a simulated environment, a time gap in the coordinates set happens roughly once every 100000 readings (during source tracking).
-
-    issue #411 - The WeatherStation component `getData` method now returns the last known set of weather parameters, without interrogating the hardware every time it was called. Previously, having N clients calling this method resulted in having N times the socket busy. One of the clients was for example the Refraction component, which introduced additional latencies and time gaps into the AntennaBoss WatchingThread.
-
-    issue #382 - The Refraction `getCorrection` method now returns a VALUE of 0 when the antenna is pointing to the zenith (or when the elvation is encoded with more than 90 degrees). Previously, the method returned a POINTER equal to 0, which surprisingly never caused any issue other than flooding the jlog with a warning message.
-
-    issue #402 - Fixed an issue in the ReceiversBossTui that was preventing the UI to find any derotator in the system.
-
-##
-
-
 ## [discos1.0] 07-11-2018
 ### Added
 
@@ -58,4 +35,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/
 
     issue #367 - The PyCalmux component now uses a smarter way to open a socket to the CalMux device in order to avoid raising unwanted socket errors.
 
-##
+
+## [discos1.0.2] 01-08-2019
+### Added
+### Changed
+
+    issue #423 - The SRT Active Surface now is monitored by 8 threads (the same threads that perform its initialization). The USDs statuses are updated inside these threads (roughly once every 15 seconds). The `usdStatus4GUI` method now returns the last read status of the given USD instead of interrogating the hardware in real time. The changes brought to the SRT Active Surface allowed its GUI to be improved. Since now it asks for the last known status of every USD without interrogating the hardware in real time, the thread is able to go from USD to USD in 10ms instead of 100ms. A complete loop of the USDs now lasts less than 15 seconds, the UI therefore appears much more responsive to the users, allowing them to send commands to the AS earlier than before (the startup time of the whole AS is approximately the same, but the UI catches up more quickly when the ASBoss is ready).
+
+    issue #404 - Minor fixes were introduced in the SRT test CDB.
+
+    feature - The TimeTaggedCircularArray class is now thread safe.
+
+### Fixed
+
+    issue #431 - The AntennaBoss WatchingThread is now free to read updated values from the mount component without starving. This was tested in the SRT environment with the ACU simulator. No tests were carried on in the Medicina/Noto environments, but due to the different socket nature of the ACU, this should not be an issue. In a simulated environment, a time gap in the coordinates set happens roughly once every 100000 readings (during source tracking).
+
+    issue #411 - The WeatherStation component `getData` method now returns the last known set of weather parameters, without interrogating the hardware every time it was called. Previously, having N clients calling this method resulted in having N times the socket busy. One of the clients was for example the Refraction component, which introduced additional latencies and time gaps into the AntennaBoss WatchingThread.
+
+    issue #382 - The Refraction `getCorrection` method now returns a VALUE of 0 when the antenna is pointing to the zenith (or when the elvation is encoded with more than 90 degrees). Previously, the method returned a POINTER equal to 0, which surprisingly never caused any issue other than flooding the jlog with a warning message.
+
+    issue #402 - Fixed an issue in the ReceiversBossTui that was preventing the UI to find any derotator in the system.
+
+## [discosX.X.x]
+### Added
+### Changed
+### Added
+### Fixed
+     issue #452 - The Total Power component erronously assigned a timestamp to the samples in case more samples were needed to reach total integration time

--- a/Common/Servers/TotalPower/src/Protocol.cpp
+++ b/Common/Servers/TotalPower/src/Protocol.cpp
@@ -570,13 +570,16 @@ bool CProtocol::decodeFPGATime(const DWORD& clock,const double& sampleRate,const
 	second=clockT % 60;
 	period=1.0/sampleRate; // sample rate is MHz so period is in microseconds
 	//micro=(long)(period*((double)counter-0.5)); // take the mean time
-	micro=(long)(period*((double)counter)); // I'd like to assign the time to the start of the sample!
+	// timestamp marks the start of the sample according the Total Power documentation
+	micro=(long)(period*((double)counter)); 
 	bkndTime.day(day);
 	bkndTime.hour(hour);
 	bkndTime.minute(minute);
 	bkndTime.second(second);
 	bkndTime.microSecond(micro);
 	temp=bkndTime.value().value;
+	// this allows to cope with the fact that the TP is always one sample time behind the effective timemark
+	// provided with the data buffer.
 	temp-=(long long)(period*10);   // we have to shift back the time of one period...because the sample is referred to the period before.
 	bkndTime.value(temp);
 	getReferenceTime(tm);

--- a/Common/Servers/TotalPower/src/SenderThread.cpp
+++ b/Common/Servers/TotalPower/src/SenderThread.cpp
@@ -275,8 +275,10 @@ void CSenderThread::computeSample(TSampleRecord& samp,TIMEVALUE& sampleTime,DWOR
 	samp.counts++; //increase the number of accumulations
 	if (samp.counts==samp.accumulations) { // if the required number of accumulations is reached.....
 		// computes the mean time
-		ACS::Time diff=samp.start.value().value+(sampleTime.value().value-samp.start.value().value)/2;
-		samp.start.value(diff);
+		// this code was deleted because we want assign the timestamp at the beginning of the sample even 
+		// when more than one integration is required.
+		//ACS::Time diff=samp.start.value().value+(sampleTime.value().value-samp.start.value().value)/2;
+		//samp.start.value(diff);
 		// now send the data		
 		SAMPLETYPE sample[MAX_SECTION_NUMBER];
 		double  tsys[MAX_SECTION_NUMBER],allTsys[MAX_SECTION_NUMBER];


### PR DESCRIPTION
…ffered to the start of the sampling) to the sample in all cases.

