### PR TITLE
Fix #463, SRT X band receiver pointing model updated

### DIFF
--- a/SRT/Configuration/CDB/alma/DataBlock/PointingModel/PointingModel.xml
+++ b/SRT/Configuration/CDB/alma/DataBlock/PointingModel/PointingModel.xml
@@ -107,38 +107,37 @@
 
 <Receiver>
 	<receiverCode>XB</receiverCode>
-        <phi>90.0</phi>
-        <coefficientNum00> 1 </coefficientNum00> <coefficientVal00> -2.3004031181 </coefficientVal00>
-        <coefficientNum01> 0 </coefficientNum01> <coefficientVal01> 0 </coefficientVal01>
-        <coefficientNum02> 1 </coefficientNum02> <coefficientVal02> -0.0026192311 </coefficientVal02>
-        <coefficientNum03> 1 </coefficientNum03> <coefficientVal03> 0.0150836473 </coefficientVal03>
-        <coefficientNum04> 1 </coefficientNum04> <coefficientVal04> -0.0009188211 </coefficientVal04>
-        <coefficientNum05> 1 </coefficientNum05> <coefficientVal05> -0.0014867977 </coefficientVal05>
-        <coefficientNum06> 1 </coefficientNum06> <coefficientVal06> 0.0909611434 </coefficientVal06>
-        <coefficientNum07> 1 </coefficientNum07> <coefficientVal07> 0.0859903619 </coefficientVal07>
-        <coefficientNum08> 0 </coefficientNum08> <coefficientVal08> 0 </coefficientVal08>
-        <coefficientNum09> 0 </coefficientNum09> <coefficientVal09> 0 </coefficientVal09>
-        <coefficientNum10> 1 </coefficientNum10> <coefficientVal10> 0.0158559289 </coefficientVal10>
-        <coefficientNum11> 0 </coefficientNum11> <coefficientVal11> 0 </coefficientVal11>
-        <coefficientNum12> 1 </coefficientNum12> <coefficientVal12> 0.0006128236 </coefficientVal12>
-        <coefficientNum13> 1 </coefficientNum13> <coefficientVal13> 0.0003877211 </coefficientVal13>
-        <coefficientNum14> 0 </coefficientNum14> <coefficientVal14> 0 </coefficientVal14>
-        <coefficientNum15> 0 </coefficientNum15> <coefficientVal15> 0 </coefficientVal15>
-        <coefficientNum16> 0 </coefficientNum16> <coefficientVal16> 0 </coefficientVal16>
-        <coefficientNum17> 0 </coefficientNum17> <coefficientVal17> 0 </coefficientVal17>
-        <coefficientNum18> 0 </coefficientNum18> <coefficientVal18> 0 </coefficientVal18>
-        <coefficientNum19> 0 </coefficientNum19> <coefficientVal19> 0 </coefficientVal19>
-        <coefficientNum20> 0 </coefficientNum20> <coefficientVal20> 0 </coefficientVal20>
-        <coefficientNum21> 0 </coefficientNum21> <coefficientVal21> 0 </coefficientVal21>
-        <coefficientNum22> 0 </coefficientNum22> <coefficientVal22> 0 </coefficientVal22>
-        <coefficientNum23> 0 </coefficientNum23> <coefficientVal23> 0 </coefficientVal23>
-        <coefficientNum24> 0 </coefficientNum24> <coefficientVal24> 0 </coefficientVal24>
-        <coefficientNum25> 0 </coefficientNum25> <coefficientVal25> 0 </coefficientVal25>
-        <coefficientNum26> 0 </coefficientNum26> <coefficientVal26> 0 </coefficientVal26>
-        <coefficientNum27> 0 </coefficientNum27> <coefficientVal27> 0 </coefficientVal27>
-        <coefficientNum28> 0 </coefficientNum28> <coefficientVal28> 0 </coefficientVal28>
-        <coefficientNum29> 0 </coefficientNum29> <coefficientVal29> 0 </coefficientVal29>
+        <phi>90.0000</phi>
+        <coefficientNum00>1</coefficientNum00> <coefficientVal00>-2.2958853245</coefficientVal00>
+        <coefficientNum01>0</coefficientNum01> <coefficientVal01>0.0000000000</coefficientVal01>
+        <coefficientNum02>1</coefficientNum02> <coefficientVal02>-0.0028010032</coefficientVal02>
+        <coefficientNum03>1</coefficientNum03> <coefficientVal03>0.0174103193</coefficientVal03>
+        <coefficientNum04>1</coefficientNum04> <coefficientVal04>-0.0006575030</coefficientVal04>
+        <coefficientNum05>1</coefficientNum05> <coefficientVal05>-0.0018693198</coefficientVal05>
+        <coefficientNum06>1</coefficientNum06> <coefficientVal06>0.0982902572</coefficientVal06>
+        <coefficientNum07>1</coefficientNum07> <coefficientVal07>0.0886350125</coefficientVal07>
+        <coefficientNum08>0</coefficientNum08> <coefficientVal08>0.0000000000</coefficientVal08>
+        <coefficientNum09>0</coefficientNum09> <coefficientVal09>0.0000000000</coefficientVal09>
+        <coefficientNum10>1</coefficientNum10> <coefficientVal10>0.0123823062</coefficientVal10>
+        <coefficientNum11>0</coefficientNum11> <coefficientVal11>0.0000000000</coefficientVal11>
+        <coefficientNum12>1</coefficientNum12> <coefficientVal12>0.0002171397</coefficientVal12>
+        <coefficientNum13>1</coefficientNum13> <coefficientVal13>-0.0000348021</coefficientVal13>
+        <coefficientNum14>0</coefficientNum14> <coefficientVal14>0.0000000000</coefficientVal14>
+        <coefficientNum15>0</coefficientNum15> <coefficientVal15>0.0000000000</coefficientVal15>
+        <coefficientNum16>0</coefficientNum16> <coefficientVal16>0.0000000000</coefficientVal16>
+        <coefficientNum17>0</coefficientNum17> <coefficientVal17>0.0000000000</coefficientVal17>
+        <coefficientNum18>0</coefficientNum18> <coefficientVal18>0.0000000000</coefficientVal18>
+        <coefficientNum19>0</coefficientNum19> <coefficientVal19>0.0000000000</coefficientVal19>
+        <coefficientNum20>0</coefficientNum20> <coefficientVal20>0.0000000000</coefficientVal20>
+        <coefficientNum21>0</coefficientNum21> <coefficientVal21>0.0000000000</coefficientVal21>
+        <coefficientNum22>0</coefficientNum22> <coefficientVal22>0.0000000000</coefficientVal22>
+        <coefficientNum23>0</coefficientNum23> <coefficientVal23>0.0000000000</coefficientVal23>
+        <coefficientNum24>0</coefficientNum24> <coefficientVal24>0.0000000000</coefficientVal24>
+        <coefficientNum25>0</coefficientNum25> <coefficientVal25>0.0000000000</coefficientVal25>
+        <coefficientNum26>0</coefficientNum26> <coefficientVal26>0.0000000000</coefficientVal26>
+        <coefficientNum27>0</coefficientNum27> <coefficientVal27>0.0000000000</coefficientVal27>
+        <coefficientNum28>0</coefficientNum28> <coefficientVal28>0.0000000000</coefficientVal28>
+        <coefficientNum29>0</coefficientNum29> <coefficientVal29>0.0000000000</coefficientVal29>
 </Receiver>
-
 
 </PointingModel>


### PR DESCRIPTION
This pointing model was obtained successfully after the tightening of the mirrors bolts and nuts.