### PR TITLE
Fix #473, implemented a strategy in order to avoid the SRT AS USDs to become unavailable too soon.

### DIFF
--- a/SRT/Servers/SRTActiveSurfaceUSDServer/include/usdImpl.h
+++ b/SRT/Servers/SRTActiveSurfaceUSDServer/include/usdImpl.h
@@ -68,6 +68,8 @@
 
 #define MM2STEP	1400 //(42000 STEP / 30 MM)
 
+#define MAX_FAILURES 5
+
 // specific macro
   /** 	@#define _ADD_MEMBER(OBJ,MEMB)
      *  This macro add extra data to an error/compl. object. MEMB must be real variable or constant
@@ -494,6 +496,11 @@ class USDImpl: public CharacteristicComponentImpl,public virtual POA_ActiveSurfa
      	* @return true if comp is an error completion else false
     	*/
 	bool compCheck(ACSErr::CompletionImpl& );
+
+    	/** 
+    	* this counts the consecutive times the USD does not respond
+    	*/
+	int m_failures;
 
     	/** 
     	* flag rappresenting the availability of the module.

--- a/SRT/Servers/SRTActiveSurfaceUSDServer/src/usdImpl.cpp
+++ b/SRT/Servers/SRTActiveSurfaceUSDServer/src/usdImpl.cpp
@@ -97,6 +97,7 @@ void USDImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 	ACS_SHORT_LOG((LM_INFO,"lan linked!"));
 
 	m_available = true;
+	m_failures = 0;
 	
 	ACE_CString CompName(this->name());
 	
@@ -662,35 +663,35 @@ void USDImpl::exImplCheck(ASErrors::ASErrorsExImpl ex)
             {
              //   _THROW_EX(LibrarySocketError,"::usdImpl::exImplCheck()",err);
 			    ACS_SHORT_LOG((LM_CRITICAL,"Critical exception %d",err));
-                m_available=false;
+                m_failures++;
                 break;
             }
 		case ASErrors::USDConnectionError: 
             {
              //   _THROW_EX(USDConnectionError,"::usdImpl::exImplCheck()",err);
 			    ACS_SHORT_LOG((LM_CRITICAL,"Critical exception %d",err));
-                m_available=false;
+                m_failures++;
                 break;
             }
 		case ASErrors::USDTimeout: 
             {
              //   _THROW_EX(USDTimeout,"::usdImpl::exImplCheck()",err);
 			    ACS_SHORT_LOG((LM_CRITICAL,"Critical exception %d",err));
-                m_available=false;
+                m_failures++;
                 break;
             }
 		case ASErrors::SocketTOut:
             {
              //   _THROW_EX(SocketTOut,"::usdImpl::exImplCheck()",err);
 			    ACS_SHORT_LOG((LM_CRITICAL,"Critical exception %d",err));
-                m_available=false;
+                m_failures++;
                 break;
             }
 		case ASErrors::SocketFail: 
 		    {
              //   _THROW_EX(SocketFail,"::usdImpl::exImplCheck()",err);
 			    ACS_SHORT_LOG((LM_CRITICAL,"Critical exception %d",err));
-                m_available=false;
+                m_failures++;
 			    break;
             }
 
@@ -702,6 +703,8 @@ void USDImpl::exImplCheck(ASErrors::ASErrorsExImpl ex)
 			    break;
             }
 	}
+	if (m_failures == MAX_FAILURES)
+		m_available=false;
     
 	ex.log();
 }
@@ -719,7 +722,8 @@ bool USDImpl::compCheck(ACSErr::CompletionImpl& comp)
 	ACS_TRACE("USDImpl::compCheck()");
 
 	if(comp.isErrorFree())	{
-	return false;
+		m_failures = 0;
+		return false;
 	} else {
 		// convert a completion in C++ excpt
 		ASErrors::USDErrorExImpl ex(comp.getErrorTraceHelper()->getErrorTrace()); // senza accodamento


### PR DESCRIPTION
The USDs component now waits for at least 5 failures in a row before setting its status to unavailable.