### PR TITLE
Fix #433, slightly changed implementation for Refraction::getCorrection

### DIFF
--- a/Common/Servers/Refraction/include/RefractionCore.h
+++ b/Common/Servers/Refraction/include/RefractionCore.h
@@ -71,7 +71,7 @@ public:
 	 * @param waveLen  wave length in meters
 	 * @param corrected corrected zenith distance
 	*/
-    void getCorrection(double observed, double waveLen, double *corrected);
+    void getCorrection(double observed, double waveLen, double& corrected);
 
 	/**
 	 * This function gets meteo parameters from metrology component every one

--- a/Common/Servers/Refraction/src/RefractionCore.cpp
+++ b/Common/Servers/Refraction/src/RefractionCore.cpp
@@ -115,7 +115,7 @@ void CRefractionCore::cleanUp()
 	}
 }
 
-void CRefractionCore::getCorrection(double obsZenithDistance,double waveLen, double *corZenithDistance)
+void CRefractionCore::getCorrection(double obsZenithDistance,double waveLen, double &corZenithDistance)
 {
 	AUTO_TRACE("CRefractionCore::getCorrection()");
 	//double elevation;
@@ -130,9 +130,9 @@ void CRefractionCore::getCorrection(double obsZenithDistance,double waveLen, dou
 		double tlr = 0.0065;
 		double eps = 1e-8;
 
-		slaRefro(obsZenithDistance, hm, tdk, m_pressure, m_humidity, wl, phi, tlr, eps, corZenithDistance);
+		slaRefro(obsZenithDistance, hm, tdk, m_pressure, m_humidity, wl, phi, tlr, eps, *corZenithDistance);
 	}
-	else *corZenithDistance = (double)0;
+	else corZenithDistance = 0.0;
 }
 
 void CRefractionCore::getMeteoParameters()

--- a/Common/Servers/Refraction/src/RefractionImpl.cpp
+++ b/Common/Servers/Refraction/src/RefractionImpl.cpp
@@ -98,7 +98,7 @@ void RefractionImpl::getCorrection (CORBA::Double obsZenithDistance,CORBA::Doubl
     //CSecAreaResourceWrapper<CRefractionCore> resource=m_core->Get();
 
 	//resource->getCorrection(obsZenithDistance, &corZenithDistance);	
-	boss->getCorrection(obsZenithDistance,waveLength,&corZenithDistance);
+	boss->getCorrection(obsZenithDistance,waveLength,corZenithDistance);
 }
 
 /* --------------- [ MACI DLL support functions ] -----------------*/


### PR DESCRIPTION
The variable in which the refraction correction is stored is now passed by reference instead of being passed by pointer. This ensures the variable always have a meaningful value instead of having to assign a value to a pointer which can often lead to errors.