### PR TITLE
Fix #477, removed the SecureArea from some AntennaBoss methods

### DIFF
--- a/Common/Servers/AntennaBoss/include/AntennaBossImpl.h
+++ b/Common/Servers/AntennaBoss/include/AntennaBossImpl.h
@@ -673,6 +673,7 @@ private:
 	SmartPropertyPointer<ROdouble> m_pdeclinationOffset;
 	SmartPropertyPointer<ROdouble> m_plongitudeOffset;
 	SmartPropertyPointer<ROdouble> m_platitudeOffset;
+	CBossCore *m_boss;
 	IRA::CSecureArea<CBossCore> *m_core;
 	CWorkingThread *m_workingThread;
 	CWatchingThread *m_watchingThread;


### PR DESCRIPTION
The said methods are the following:
getObservedHorizontal
getObservedEquatorial
getObservedGalactic
getRawHorizontal
The SecureArea was removed because the TimeTaggedCircularArray objects that these methods use to retrieve the desired coordinates are thread safe objects that do not need further, higher level, syncronization. This will avoid unwanted delays every time one of the above methods is called when the AntennaBoss is sending new coordinates to the mount. This affects all the stations.