### PR TITLE
Fix #476, replaced all occurrencies of `DPI/2` with `DPIBY2`.

### DIFF
--- a/Common/Libraries/IRALibrary/src/IRATools.cpp
+++ b/Common/Libraries/IRALibrary/src/IRATools.cpp
@@ -841,7 +841,7 @@ bool CIRATools::latitudeToRad(const IRA::CString& lat,double& rad,bool complete,
 		res=sexagesimalAngleToRad(lat,rad,complete,delimiter);
 	}
 	if (complete) {
-		if ((rad<-(DPI/2)) || (rad>(DPI/2))) return false;
+		if (rad<-DPIBY2 || rad>DPIBY2) return false;
 		else return res;
 	}
 	else return res;
@@ -915,7 +915,7 @@ bool CIRATools::elevationToRad(const IRA::CString& el,double& rad,bool complete)
 {
 	bool res=angleToRad(el,rad);
 	if (complete) {
-		if ((rad<0) || (rad>DPI/2)) return false;
+		if (rad<0 || rad>DPIBY2) return false;
 		else return res;
 	}
 	else return res;

--- a/Common/Misc/UserTools/src/SourceTrack.cpp
+++ b/Common/Misc/UserTools/src/SourceTrack.cpp
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
 	_CP_ printf("Horizontal coordinates:\tazimuth %.8lf°, elevation %.8lf°\n",az*DR2D,el*DR2D);
 
 
-	double obsZenithDistance=(DPI/2.0)-el;
+	double obsZenithDistance=DPIBY2-el;
 	double corZenithDistance;
 	double tdk = 13 + 273.0; // temperature
 	double wl = 36000.0;

--- a/Common/Servers/AntennaBoss/src/BossCore.cpp
+++ b/Common/Servers/AntennaBoss/src/BossCore.cpp
@@ -1023,7 +1023,7 @@ bool CBossCore::updateAttributes() throw (ComponentErrors::CORBAProblemExImpl,Co
 		loadPointingModel(m_pointingModel); // throw ComponentErrors::CouldntGetComponentExImpl
 		// get Offset from refraction;
 		try {
-			m_refraction->getCorrection(DPI/2.0-el,m_waveLength,m_refractionOffset);
+			m_refraction->getCorrection(DPIBY2-el,m_waveLength,m_refractionOffset);
 		}
 		catch (AntennaErrors::AntennaErrorsEx& ex) {  
 			_ADD_BACKTRACE(ComponentErrors::CouldntCallOperationExImpl,impl,ex,"CBossCore::updateAttributes()");
@@ -1249,7 +1249,7 @@ void CBossCore::loadTrackingPoint(const TIMEVALUE& time,bool restart) throw (Com
 		refOff=0.0;
 		try {
 			if (el>0.0) {
-				m_refraction->getCorrection(DPI/2.0-el,m_waveLength,refOff);
+				m_refraction->getCorrection(DPIBY2-el,m_waveLength,refOff);
 			}
 		}
 		catch (AntennaErrors::AntennaErrorsEx& ex) {

--- a/Common/Servers/Refraction/src/RefractionCore.cpp
+++ b/Common/Servers/Refraction/src/RefractionCore.cpp
@@ -122,7 +122,7 @@ void CRefractionCore::getCorrection(double obsZenithDistance,double waveLen, dou
 	baci::ThreadSyncGuard guardParametes(&m_parametersMutex);
 	//elevation = 90.0 - obsZenithDistance*DR2D;
 	//if (elevation >= 0.0 && elevation <= 90.0) {
-	if ((obsZenithDistance>=0.0) && (obsZenithDistance<=(DPI/2.0))) {
+	if (obsZenithDistance>=0.0 && obsZenithDistance<DPIBY2) {
 		double hm = m_site.getHeight(); // meters
 		double tdk = m_temperature + 273.0;
 		double wl = waveLen*1000000; //micro meters


### PR DESCRIPTION
We observed in the past that dividing the PI value by two during runtime results in a slightly greater value than the `DPIBY2` value, which is already defined correctly in the same library as `DPI`.
This sometimes resulted in a calculation of the refraction correction with elevation values slightly greater than 90°. I'm not completely sure, but this issue could be related to #433.