### PR TITLE
Fix #481, implemented the `SRTActiveSurfaceUSDServer::getStatus()` method

### DIFF
--- a/SRT/Interfaces/SRTActiveSurfaceInterface/idl/usd.idl
+++ b/SRT/Interfaces/SRTActiveSurfaceInterface/idl/usd.idl
@@ -1,16 +1,17 @@
 #ifndef _USD_IDL_
 #define _USD_IDL_
 
-/*******************************************************************************
-* "@(#) $Id: usd.idl,v 1.2 2010-07-26 12:34:49 c.migoni Exp $"
-*
-* who       when      what
-* --------  --------  ----------------------------------------------
-* GMM       sept 2005   creation	
-* CM	    jan 2013  ACS 8.0.1 adaptions
-* CM	    jan 2013  All code revised and adapted to be used from SRTActiveSurfaceBoss component
-* CM	    jan 2013  calibrate and calVer routines transformed to oneway
-*/
+/****************************************************************************************************/
+/* "@(#) $Id: usd.idl,v 1.2 2010-07-26 12:34:49 c.migoni Exp $"                                     */
+/*                                                                                                  */
+/* who      when        what                                                                        */
+/* -------- --------    ----------------------------------------------                              */
+/* GMM		sept 2005	creation                                                                    */
+/* CM		jan 2013	ACS 8.0.1 adaptions                                                         */
+/* CM		jan 2013	All code revised and adapted to be used from SRTActiveSurfaceBoss component */
+/* CM		jan 2013	calibrate and calVer routines transformed to oneway                         */
+/* GC		nov 2019	added getStatus method and reviewed indentation                             */
+/****************************************************************************************************/
 
 #include <baci.idl>
 #include <ASErrors.idl>
@@ -19,173 +20,171 @@
 
 module ActiveSurface
 {
-
-   /** @interface USD
-     *  This interface rappresents a single AS actuator device.
-     *  It provides property rapresenting all the actuators variable and methods
-		 *  implementing the most usefull action that an actuator (USD) can do.
-     */
-     interface USD : ACS::CharacteristicComponent
+	/** @interface USD
+	*  This interface rappresents a single AS actuator device.
+	*  It provides property rapresenting all the actuators variable and methods
+	*  implementing the most usefull action that an actuator (USD) can do.
+	*/
+	interface USD : ACS::CharacteristicComponent
 	{
-	
-    	/**
-    	*	the on-reply delay.
-    	* 	Usd has a timer for the delay between the last received byte and the transmitter activation. The default is often not enaugh. 
-    	*/
-    	readonly attribute ACS::RWlong delay;
-    	
-    	/**
-    	*	the last commanded absolute position (ustep)
-    	*/
-    	readonly attribute ACS::RWlong cmdPos;
-    	
-    	
-    	/**
-    	*	the starting velocity (Hz, means step/sec)
-    	*/
-    	readonly attribute ACS::RWlong Fmin;
-    	
-    	/**
-    	*	the duty velocity (Hz, means step/sec)
-    	*	the max speed is 10KHZ
-    	*/
-    	readonly attribute ACS::RWlong Fmax;
-    	
-    	/**
-    	*	the acceleration factor.
-    	* 	Usd has a minimal internal acceleration ramp of ~100KHz/sec.  
-    	*  This number relax the base ramp  of factor+1 times,
-    	*  i.e. 99 means an acceleration of 1KHz/sec
-    	*/
-    	readonly attribute ACS::RWlong acc;
-    	
-    	/**
-    	*	configure the USD users bits
-    	*/
-    	readonly attribute ACS::RWlong uBits;
-    	
-      /**
-    	*	last minute correction
-    	*/
-    	readonly attribute ACS::RWdouble lmCorr;
-    	
-			/**
-    	*	the actual absolute position (ustep)
-    	*/
-    	readonly attribute ACS::ROlong actPos;
-    	
-    	/**
-    	*	the status of USD.
-    	*	byte 2: unused.\n
-    	*	byte 1: n.u.(MSB),DIO2,DIO1,DIO0,n.u.,fault,driv_on,zero. \n
-    	*	byte 0: run(MSB),differ_exec,ready,stnby,auto,RS2,RS1,RS0. \n
-    	*/
-    	readonly attribute ACS::ROpattern status;
-    	
-    	/**
-    	*	the USD software version (must be 1.3).
-    	*	this command is often use to check the USD availability
-    	*/
-    	readonly attribute ACS::ROlong softVer;
-    	
-    	/**
-    	*	the USD type (must be 0x21 USD60xxx)
-    	*/
-    	readonly attribute ACS::ROlong type;
-    	
 		/**
-    	*	gravity correction
-    	*/
-    	readonly attribute ACS::RWdouble gravCorr;
-    	
-    	/**
-    	*	user offset
-    	*/
-    	readonly attribute ACS::RWdouble userOffset;
-    	
-    	/**
-    	*	stop immediate with ramp
-    	*/
-    	oneway void stop();
-    	
-    	/**
-    	*	soft reset of USD. 
-    	*	The position counter will be resetted and the link will restart at 9600bps
-    	*/
-    	void reset();
-    	
-    	/**
-    	*	move up(out) and down(in) the actuator untill a stop.
-    	*	the  command must be sent only when motor is stopped
-    	*/
-    	oneway void up();
-    	oneway void down();
-    	
-    	/**
-    	*	move relative to actual position of an amount of ustep. 
-    	*	@param incr the amount to move in ustep. negative number means move down(in).
-    	*/
-    	oneway void move(in long incr);
-    	
-		/**
-    	*	makes the scale calibration. USD must be against the upper edge. 
-    	*	@return 
-    	*/
-    	//ACSErr::Completion calibrate() raises (ASErrors::ASErrorsEx);
-    	oneway void calibrate();
+		*	the on-reply delay.
+		* 	Usd has a timer for the delay between the last received byte and the transmitter activation. The default is often not enough.
+		*/
+		readonly attribute ACS::RWlong delay;
 
 		/**
-    	*	makes the scale verification. 
-    	*	@return a completion with the result of verification
-			*	@throw  ASErrors::USDUnavailableEx or ASErrors::USDunCalibratedEx if the USD is not available or calibrated.
-    	*/
-	//ACSErr::Completion calVer() raises (ASErrors::ASErrorsEx);
-	oneway void calVer();
-
-	/**
-	* writes calibration results into CDB
-	*/
-	void writeCalibration(out double cammaLenD, out double cammaPosD, out boolean calibrate) raises (ASErrors::ASErrorsEx);
-
-	/**
-	* sets actuators corrections table
-	*/
-	void posTable (in ACS::doubleSeq actuatorsCorrections, in long parPositions, in double deltaEL, in long threshold);
+		*	the last commanded absolute position (ustep)
+		*/
+		readonly attribute ACS::RWlong cmdPos;
 
 		/**
-    	*	go to reference position. 
-    	*	@return 
-    	*/
-    	oneway void refPos();
+		*	the starting velocity (Hz, means step/sec)
+		*/
+		readonly attribute ACS::RWlong Fmin;
 
 		/**
-    	*	set the profile, 0 shaped, 1 parabolic, 2 parabolic fixed. 
-    	*/
-    	void setProfile(in long prof) raises (ASErrors::ASErrorsEx);
+		*	the duty velocity (Hz, means step/sec)
+		*	the max speed is 10KHZ
+		*/
+		readonly attribute ACS::RWlong Fmax;
 
 		/**
-    	*	set the last minute corrections. 
-    	*/
-    	oneway void correction(in double corr);
+		*	the acceleration factor.
+		* 	Usd has a minimal internal acceleration ramp of ~100KHz/sec.
+		*  This number relax the base ramp  of factor+1 times,
+		*  i.e. 99 means an acceleration of 1KHz/sec
+		*/
+		readonly attribute ACS::RWlong acc;
 
 		/**
-    	*	recalculates the gravity and user corrections based on antenna elevation. 
-    	*/
-    	oneway void update(in double elev);
-    	/* oneway void update(in long position); */
-		
-		/**
-    	*	stow and setup  
-    	*/
-    	oneway void stow();
-    	oneway void setup();
+		*	configure the USD users bits
+		*/
+		readonly attribute ACS::RWlong uBits;
 
 		/**
-    	*	move to most top or bottom positions. These are reached in subsequent movements of maxRun lenght  
-    	*/
-    	oneway void top();
-    	oneway void bottom();
+		*	last minute correction
+		*/
+		readonly attribute ACS::RWdouble lmCorr;
+
+		/**
+		*	the actual absolute position (ustep)
+		*/
+		readonly attribute ACS::ROlong actPos;
+
+		/**
+		*	the status of USD.
+		*	byte 2: unused.\n
+		*	byte 1: n.u.(MSB),DIO2,DIO1,DIO0,n.u.,fault,driv_on,zero. \n
+		*	byte 0: run(MSB),differ_exec,ready,stnby,auto,RS2,RS1,RS0. \n
+		*/
+		readonly attribute ACS::ROpattern status;
+
+		/**
+		*	the USD software version (must be 1.3).
+		*	this command is often use to check the USD availability
+		*/
+		readonly attribute ACS::ROlong softVer;
+
+		/**
+		*	the USD type (must be 0x21 USD60xxx)
+		*/
+		readonly attribute ACS::ROlong type;
+
+		/**
+		*	gravity correction
+		*/
+		readonly attribute ACS::RWdouble gravCorr;
+
+		/**
+		*	user offset
+		*/
+		readonly attribute ACS::RWdouble userOffset;
+
+		/**
+		*	stop immediate with ramp
+		*/
+		oneway void stop();
+
+		/**
+		*	soft reset of USD.
+		*	The position counter will be resetted and the link will restart at 9600bps
+		*/
+		void reset();
+
+		/**
+		*	move up(out) and down(in) the actuator untill a stop.
+		*	the  command must be sent only when motor is stopped
+		*/
+		oneway void up();
+		oneway void down();
+
+		/**
+		*	move relative to actual position of an amount of ustep.
+		*	@param incr the amount to move in ustep. negative number means move down(in).
+		*/
+		oneway void move(in long incr);
+
+		/**
+		*	makes the scale calibration. USD must be against the upper edge.
+		*	@return
+		*/
+		oneway void calibrate();
+
+		/**
+		*	makes the scale verification.
+		*	@return a completion with the result of verification
+		*	@throw  ASErrors::USDUnavailableEx or ASErrors::USDunCalibratedEx if the USD is not available or calibrated.
+		*/
+		oneway void calVer();
+
+		/**
+		* writes calibration results into CDB
+		*/
+		void writeCalibration(out double cammaLenD, out double cammaPosD, out boolean calibrate) raises (ASErrors::ASErrorsEx);
+
+		/**
+		* sets actuators corrections table
+		*/
+		void posTable (in ACS::doubleSeq actuatorsCorrections, in long parPositions, in double deltaEL, in long threshold);
+
+		/**
+		*	go to reference position.
+		*	@return
+		*/
+		oneway void refPos();
+
+		/**
+		*	set the profile, 0 shaped, 1 parabolic, 2 parabolic fixed.
+		*/
+		void setProfile(in long prof) raises (ASErrors::ASErrorsEx);
+
+		/**
+		*	set the last minute corrections.
+		*/
+		oneway void correction(in double corr);
+
+		/**
+		*	recalculates the gravity and user corrections based on antenna elevation.
+		*/
+		oneway void update(in double elev);
+
+		/**
+		*	stow and setup
+		*/
+		oneway void stow();
+		oneway void setup();
+
+		/**
+		*	move to most top or bottom positions. These are reached in subsequent movements of maxRun lenght
+		*/
+		oneway void top();
+		oneway void bottom();
+
+		/*
+		*	gets the last known status of the UDS
+		*/
+		void getStatus(out long status);
 	};
-
 };
 #endif /* _USD_ */

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossCore.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossCore.cpp
@@ -1642,13 +1642,9 @@ void CSRTActiveSurfaceBossCore::setActuator(int circle, int actuator, long int& 
 
 void CSRTActiveSurfaceBossCore::usdStatus4GUIClient(int circle, int actuator, CORBA::Long_out status) throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::CouldntGetAttributeExImpl, ComponentErrors::ComponentNotActiveExImpl)
 {
-	ACS::ROpattern_var status_var;
-    	ACSErr::Completion_var completion;
-
     	if (!CORBA::is_nil(usd[circle][actuator])) {
         	try {
-            		status_var = usd[circle][actuator]->status ();
-            		status = status_var->get_sync (completion.out ());
+                usd[circle][actuator]->getStatus(status);
         	}
         	catch (CORBA::SystemException& ex) {
             		_EXCPT(ComponentErrors::CORBAProblemExImpl,impl,"CSRTActiveSurfaceBossCore::usdStatus4GUIClient()");

--- a/SRT/Servers/SRTActiveSurfaceUSDServer/include/usdImpl.h
+++ b/SRT/Servers/SRTActiveSurfaceUSDServer/include/usdImpl.h
@@ -1,17 +1,15 @@
 #ifndef USDImpl_h
 #define USDImpl_h
 
-/*******************************************************************************
-*
-* "@(#) $Id: usdImpl.h,v 1.1 2011-03-24 09:18:00 c.migoni Exp $"
-*
-* who       when      what
-* --------  --------  ----------------------------------------------
-* GMM       jul 2005   creation				   
-* CM	    jan 2013  ACS 8.0.1 adaptions
-* CM	    jan 2013  All code revised and adapted to be used from SRTActiveSurfaceBoss component
-*/
-
+/****************************************************************************************************/
+/* "@(#) $Id: usdImpl.h,v 1.1 2011-03-24 09:18:00 c.migoni Exp $"									*/
+/*																									*/
+/* who		when		what																		*/
+/* --------	--------	----------------------------------------------								*/
+/* GMM		jul 2005	creation																	*/
+/* CM		jan 2013	ACS 8.0.1 adaptions															*/
+/* CM		jan 2013	All code revised and adapted to be used from SRTActiveSurfaceBoss component	*/
+/****************************************************************************************************/
 
 #ifndef __cplusplus
 #error This is a C++ include file and cannot be used from plain C
@@ -38,7 +36,7 @@
 #include <usdDevIO.h>
 
 /// ustep to step exp. 2 factor (2^7=128)
-#define USxS 		7	
+#define USxS	7
 
 // mask pattern for status 
 #define MRUN	0x000080
@@ -64,205 +62,249 @@
 #define	USDT	0x14
 #define CPOS	0x30
 #define RPOS	0x31
-#define GO	0x32
+#define GO		0x32
 
 #define MM2STEP	1400 //(42000 STEP / 30 MM)
 
 #define MAX_FAILURES 5
 
-// specific macro
-  /** 	@#define _ADD_MEMBER(OBJ,MEMB)
-     *  This macro add extra data to an error/compl. object. MEMB must be real variable or constant
-     *	@param OBJ error or completion object
-		 *	@param MEMB costant or variable added as (name,value) pair
-     */
-#define _ADD_MEMBER(OBJ,MEMB) { \
-	CString mName(#MEMB); \
-	CString mVal;mVal.Format("%02x",MEMB); \
-	_ADD_EXTRA(OBJ,mName,mVal); \
+// specific macros
+
+/** @#define _ADD_MEMBER(OBJ, MEMB)
+*	This macro add extra data to an error/compl. object. MEMB must be real variable or constant
+*	@param OBJ error or completion object
+*	@param MEMB costant or variable added as (name,value) pair
+*/
+#define _ADD_MEMBER(OBJ, MEMB)\
+{\
+	CString mName(#MEMB);\
+	CString mVal;\
+	mVal.Format("%02x", MEMB);\
+	_ADD_EXTRA(OBJ, mName, mVal);\
 }
 
-  /** 	@#define _THROW_EX(ERR,ROUTINE,VAR)
-     *  Create and launch a remote (CORBA) exception, adding USD address and VAR as addedd data
-     *	@param ERR error 
-     *	@param ROUTINE the calling routine 
-		 *	@param VAR costant or variable added as (name,value) pair
-     */
-#define _THROW_EX(ERR,ROUTINE,VAR) { \
-				ASErrors::ERR##ExImpl exImpl(__FILE__,__LINE__,ROUTINE); \
-				_ADD_MEMBER(exImpl,m_addr); \
-				_ADD_MEMBER(exImpl,VAR); \
-				throw exImpl.getASErrorsEx(); \
-		}
-
-  /** 	@#define _VAR_CHK_EXIMPL(VAR,ERR,ROUTINE)
-     *  Launch a local exception if VAR is not true.
-     *	@param VAR variable to be checked
-		 *	@param ERR error 
-     *	@param ROUTINE the calling routine 
-     */
-#define _VAR_CHK_EXIMPL(VAR,ERR,ROUTINE) { \
-					if(!VAR) throw ASErrors::ERR##ExImpl(__FILE__,__LINE__,ROUTINE);\
-} \
-
-  /** 	@#define _VAR_CHK_EX(VAR,ERR,ROUTINE)
-     *  Launch a remote(CORBA) exception if VAR is not true.
-     *	@param VAR variable to be checked
-		 *	@param ERR error 
-     *	@param ROUTINE the calling routine 
-     */
-#define _VAR_CHK_EX(VAR,ERR,ROUTINE) \
-					if(!VAR) throw ASErrors::ERR##ExImpl(__FILE__,__LINE__,ROUTINE).getASErrorsEx();
-
-  /** 	@#define _COMPL_CHK_THROW_EX(CP_SP,OUT_TYPE,ROUTINE)
-     *  Check a remote(CORBA) completion_var. Launch an remotem OUT_TYPE CORBA exception 
-		 *	if it is not error free.
-     *	@param CP_SP Complition_var smart pointer 
-		 *	@param OUT_TYPE out type exception 
-     *	@param ROUTINE the calling routine 
-     */
-		 #define _COMPL_CHK_THROW_EX(CP_SP,OUT_TYPE,ROUTINE) { \
-			 ACSErr::CompletionImpl comp(CP_SP.in());\
-			 if (compCheck(comp)) \
-				 throw ASErrors::OUT_TYPE##ExImpl(comp,__FILE__,__LINE__,ROUTINE).getASErrorsEx();\
+/** @#define _THROW_EX(ERR, ROUTINE, VAR)
+*	Create and launch a remote (CORBA) exception, adding USD address and VAR as addedd data
+*	@param ERR error
+*	@param ROUTINE the calling routine
+*	@param VAR costant or variable added as (name,value) pair
+*/
+#define _THROW_EX(ERR, ROUTINE, VAR)\
+{\
+	ASErrors::ERR##ExImpl exImpl(__FILE__, __LINE__, ROUTINE);\
+	_ADD_MEMBER(exImpl, m_addr);\
+	_ADD_MEMBER(exImpl, VAR);\
+	throw exImpl.getASErrorsEx();\
 }
 
- /** 	@#define _SET_CDB(PROP,LVAL,ROUTINE) throw (ASErrors::CDBAccessErrorExImpl)
-     *  Set a long CDB property or attribute.
-     *	@param PROP property to be setted
-		 *	@param LVAL the value 
-     *	@param ROUTINE the calling routine 
-     */
-#define _SET_CDB(PROP,LVAL,ROUTINE) {	\
-	maci::ContainerServices* cs=getContainerServices();\
-		if (!CIRATools::setDBValue(cs,#PROP,(const long&) LVAL)) \
-		{ ASErrors::CDBAccessErrorExImpl exImpl(__FILE__,__LINE__,ROUTINE); \
-			exImpl.setFieldName(#PROP); throw exImpl; \
-		} \
+/** @#define _VAR_CHK_EXIMPL(VAR, ERR, ROUTINE)
+*	Launch a local exception if VAR is not true.
+*	@param VAR variable to be checked
+*	@param ERR error
+*	@param ROUTINE the calling routine
+*/
+#define _VAR_CHK_EXIMPL(VAR, ERR, ROUTINE)\
+{\
+	if(!VAR)\
+	{\
+		throw ASErrors::ERR##ExImpl(__FILE__, __LINE__, ROUTINE);\
+	}\
 }
 
- /** 	@#define _SET_CDB_D(PROP,LVAL,ROUTINE) throw (ASErrors::CDBAccessErrorExImpl)
-     *  Set a double CDB property or attribute.
-     *	@param PROP property to be setted
-		 *	@param LVAL the value 
-     *	@param ROUTINE the calling routine 
-     */
-#define _SET_CDB_D(PROP,LVAL,ROUTINE) {	\
-	maci::ContainerServices* cs=getContainerServices();\
-		if (!CIRATools::setDBValue(cs,#PROP,(const double&) LVAL)) \
-		{ ASErrors::CDBAccessErrorExImpl exImpl(__FILE__,__LINE__,ROUTINE); \
-			exImpl.setFieldName(#PROP); throw exImpl; \
-		} \
-}
-/*		{ ASErrors::CDBAccessErrorExImpl ex=ASErrors::CDBAccessErrorExImpl(__FILE__,__LINE__,ROUTINE); 
-			ex.setFieldName(#PROP); throw ex.getASErrorsEx(); */
-
- /** 	@#define _GET_PROP(PROP,RETVAR,ROUTINE)
-     *  Get a property value.
-     *	@param PROP property to be read
-		 *	@param RETVAR the value 
-     *	@param ROUTINE the calling routine 
-		 *	@throw a DevIOError remote exception if return completion is not error free
-     */
-#define _GET_PROP(PROP,RETVAR,ROUTINE) { \
-			ACSErr::Completion_var sm_cp; \
-			RETVAR=m_##PROP##_sp->get_sync(sm_cp.out()); \
-			 ACSErr::CompletionImpl comp(sm_cp.in());\
-			 if (compCheck(comp)) \
-				 throw ASErrors::DevIOErrorExImpl(comp,__FILE__,__LINE__,ROUTINE).getDevIOErrorEx();\
+/** @#define _VAR_CHK_EX(VAR, ERR, ROUTINE)
+*	Launch a remote(CORBA) exception if VAR is not true.
+*	@param VAR variable to be checked
+*	@param ERR error
+*	@param ROUTINE the calling routine
+*/
+#define _VAR_CHK_EX(VAR, ERR, ROUTINE) \
+{\
+	if(!VAR)\
+	{\
+		throw ASErrors::ERR##ExImpl(__FILE__, __LINE__, ROUTINE).getASErrorsEx();\
+	}\
 }
 
- /** 	@#define _SET_PROP(PROP,RETVAR,ROUTINE)
-     *  Set a property value.
-     *	@param PROP property to be read
-	 *	@param VALUE property value to be changed
-     *	@param ROUTINE the calling routine 
-	 *	@throw a DevIOError remote exception if return completion is not error free
-     */
-#define _SET_PROP(PROP,VALUE,ROUTINE) {\
-			ACSErr::CompletionImpl comp=m_##PROP##_sp->set_sync(VALUE);\
-			 if (compCheck(comp)) \
-				 throw ASErrors::DevIOErrorExImpl(comp,__FILE__,__LINE__,ROUTINE).getDevIOErrorEx();\
+/** @#define _COMPL_CHK_THROW_EX(CP_SP, OUT_TYPE, ROUTINE)
+*	Check a remote(CORBA) completion_var. Launch an remotem OUT_TYPE CORBA exception 
+*	if it is not error free.
+*	@param CP_SP Complition_var smart pointer 
+*	@param OUT_TYPE out type exception 
+*	@param ROUTINE the calling routine 
+*/
+#define _COMPL_CHK_THROW_EX(CP_SP, OUT_TYPE, ROUTINE)\
+{\
+	ACSErr::CompletionImpl comp(CP_SP.in());\
+	if(compCheck(comp))\
+	{\
+		throw ASErrors::OUT_TYPE##ExImpl(comp, __FILE__, __LINE__, ROUTINE).getASErrorsEx();\
+	}\
 }
 
- /** 	@#define _SET_LDEF(PROP,ROUTINE)
-     *  Set the default value for given property. All type except double.
-		 *	Launch a remote exception if set_sync return completion is not error free.
-     *	@param PROP property 
-     *	@param ROUTINE the calling routine 
-     */
-#define _SET_LDEF(PROP,ROUTINE) {	\
+/** @#define _SET_CDB(PROP, LVAL, ROUTINE) throw (ASErrors::CDBAccessErrorExImpl)
+*	Set a long CDB property or attribute.
+*	@param PROP property to be setted
+*	@param LVAL the value 
+*	@param ROUTINE the calling routine 
+*/
+#define _SET_CDB(PROP, LVAL, ROUTINE)\
+{\
+	maci::ContainerServices* cs = getContainerServices();\
+	if(!CIRATools::setDBValue(cs, #PROP, (const long&)LVAL))\
+	{\
+		ASErrors::CDBAccessErrorExImpl exImpl(__FILE__, __LINE__, ROUTINE);\
+		exImpl.setFieldName(#PROP);\
+		throw exImpl;\
+	}\
+}
+
+/** @#define _SET_CDB_D(PROP, LVAL, ROUTINE) throw (ASErrors::CDBAccessErrorExImpl)
+*	Set a double CDB property or attribute.
+*	@param PROP property to be setted
+*	@param LVAL the value 
+*	@param ROUTINE the calling routine 
+*/
+#define _SET_CDB_D(PROP, LVAL, ROUTINE)\
+{\
+	maci::ContainerServices* cs = getContainerServices();\
+	if(!CIRATools::setDBValue(cs, #PROP, (const double&)LVAL))\
+	{\
+		ASErrors::CDBAccessErrorExImpl exImpl(__FILE__, __LINE__, ROUTINE);\
+		exImpl.setFieldName(#PROP);\
+		throw exImpl;\
+	}\
+}
+
+/** @#define _GET_PROP(PROP, RETVAR, ROUTINE)
+*	Get a property value.
+*	@param PROP property to be read
+*	@param RETVAR the value 
+*	@param ROUTINE the calling routine 
+*	@throw a DevIOError remote exception if return completion is not error free
+*/
+#define _GET_PROP(PROP, RETVAR, ROUTINE)\
+{\
+	ACSErr::Completion_var sm_cp;\
+	RETVAR = m_##PROP##_sp->get_sync(sm_cp.out()); \
+	ACSErr::CompletionImpl comp(sm_cp.in());\
+	if (compCheck(comp))\
+	{\
+		throw ASErrors::DevIOErrorExImpl(comp, __FILE__, __LINE__, ROUTINE).getDevIOErrorEx();\
+	}\
+}
+
+/** @#define _SET_PROP(PROP, RETVAR, ROUTINE)
+*	Set a property value.
+*	@param PROP property to be read
+*	@param VALUE property value to be changed
+*	@param ROUTINE the calling routine 
+*	@throw a DevIOError remote exception if return completion is not error free
+*/
+#define _SET_PROP(PROP, VALUE, ROUTINE)\
+{\
+	ACSErr::CompletionImpl comp = m_##PROP##_sp->set_sync(VALUE);\
+	if (compCheck(comp))\
+	{\
+		throw ASErrors::DevIOErrorExImpl(comp, __FILE__, __LINE__, ROUTINE).getDevIOErrorEx();\
+	}\
+}
+
+/** @#define _SET_LDEF(PROP, ROUTINE)
+*	Set the default value for given property. All type except double.
+*	Launch a remote exception if set_sync return completion is not error free.
+*	@param PROP property 
+*	@param ROUTINE the calling routine 
+*/
+#define _SET_LDEF(PROP, ROUTINE)\
+{\
 	long tmpd;\
 	ACSErr::CompletionImpl comp;\
-	maci::ContainerServices* cs=getContainerServices();\
-		if (!CIRATools::getDBValue(cs,#PROP"/default_value",tmpd)) \
-		{ ASErrors::CDBAccessErrorExImpl ex=ASErrors::CDBAccessErrorExImpl(__FILE__,__LINE__,ROUTINE); \
-			ex.setFieldName(#PROP"/default_value"); throw ex.getASErrorsEx(); \
-		}  else comp=m_##PROP##_sp->set_sync(tmpd); \
-		if (compCheck(comp)) throw ASErrors::USDErrorExImpl(__FILE__,__LINE__,ROUTINE).getASErrorsEx(); \
+	maci::ContainerServices* cs = getContainerServices();\
+	if (!CIRATools::getDBValue(cs, #PROP"/default_value", tmpd)) \
+	{\
+		ASErrors::CDBAccessErrorExImpl ex = ASErrors::CDBAccessErrorExImpl(__FILE__, __LINE__, ROUTINE);\
+		ex.setFieldName(#PROP"/default_value");\
+		throw ex.getASErrorsEx();\
+	}\
+	else\
+	{\
+		comp = m_##PROP##_sp->set_sync(tmpd);\
+	}\
+	if (compCheck(comp))\
+	{\
+		throw ASErrors::USDErrorExImpl(__FILE__, __LINE__, ROUTINE).getASErrorsEx();\
+	}\
 }
 
- /** 	@#define _CATCH_ACS_EXCP_THROW_EXIMPL(IN_TYPE,OUT_TYPE,ROUTINE,VAR)
-     *  Catch an ACS(with error trace) exception and launch a local one (ExImpl).
-     *	@param IN_TYPE the exception to catch 
-     *	@param OUT_TYPE the exception to be launched 
-     *	@param VAR variable name and value added as addiotional data 
-     *	@param ROUTINE the calling routine 
-     */
-#define _CATCH_ACS_EXCP_THROW_EXIMPL(IN_TYPE,OUT_TYPE,ROUTINE,VAR) catch(IN_TYPE& Ex) { \
-				OUT_TYPE exImpl(Ex,__FILE__,__LINE__,ROUTINE); \
-				_ADD_MEMBER(exImpl,m_addr); \
-				_ADD_MEMBER(exImpl,VAR); \
-				throw exImpl; \
-		}
+/** @#define _CATCH_ACS_EXCP_THROW_EXIMPL(IN_TYPE,OUT_TYPE,ROUTINE,VAR)
+*	Catch an ACS(with error trace) exception and launch a local one (ExImpl).
+*	@param IN_TYPE the exception to catch 
+*	@param OUT_TYPE the exception to be launched 
+*	@param VAR variable name and value added as addiotional data 
+*	@param ROUTINE the calling routine 
+*/
+#define _CATCH_ACS_EXCP_THROW_EXIMPL(IN_TYPE, OUT_TYPE, ROUTINE,VAR)\
+catch(IN_TYPE& Ex)\
+{\
+	OUT_TYPE exImpl(Ex, __FILE__, __LINE__, ROUTINE);\
+	_ADD_MEMBER(exImpl, m_addr);\
+	_ADD_MEMBER(exImpl, VAR);\
+	throw exImpl;\
+}
 
- /** 	@#define _CATCH_EXCP_THROW_EXIMPL(IN_TYPE,OUT_TYPE,ROUTINE,VAR)
-     *  Catch an CORBA(w/o error trace) exception and launch a local one (ExImpl).
-     *	@param IN_TYPE the exception to catch 
-     *	@param OUT_TYPE the exception to be launched 
-     *	@param VAR variable name and value added as addiotional data 
-     *	@param ROUTINE the calling routine 
-     */
-#define _CATCH_EXCP_THROW_EXIMPL(IN_TYPE,OUT_TYPE,ROUTINE,VAR) catch(IN_TYPE& Ex) { \
-				OUT_TYPE exImpl(__FILE__,__LINE__,ROUTINE); \
-				_ADD_MEMBER(exImpl,m_addr); \
-				_ADD_MEMBER(exImpl,VAR); \
-				throw exImpl; \
-		}
+/** @#define _CATCH_EXCP_THROW_EXIMPL(IN_TYPE,OUT_TYPE,ROUTINE,VAR)
+*	Catch an CORBA(w/o error trace) exception and launch a local one (ExImpl).
+*	@param IN_TYPE the exception to catch 
+*	@param OUT_TYPE the exception to be launched 
+*	@param VAR variable name and value added as addiotional data 
+*	@param ROUTINE the calling routine 
+*/
+#define _CATCH_EXCP_THROW_EXIMPL(IN_TYPE, OUT_TYPE, ROUTINE, VAR)\
+catch(IN_TYPE& Ex)\
+{\
+	OUT_TYPE exImpl(__FILE__, __LINE__, ROUTINE);\
+	_ADD_MEMBER(exImpl, m_addr);\
+	_ADD_MEMBER(exImpl, VAR);\
+	throw exImpl;\
+}
 
- /** 	@#define _CATCH_ACS_EXCP_THROW_EX(IN_TYPE,OUT_TYPE,ROUTINE,VAR)
-     *  Catch an ACS(with error trace) exception and launch a remote one (Ex).
-     *	@param IN_TYPE the exception to catch 
-     *	@param OUT_TYPE the exception to be launched 
-     *	@param VAR variable name and value added as additional data 
-     *	@param ROUTINE the calling routine 
-     */
-#define _CATCH_ACS_EXCP_THROW_EX(IN_TYPE,_ERR,ROUTINE,VAR) catch(IN_TYPE& Ex) { \
-				 ASErrors::_ERR##ExImpl exImpl(Ex,__FILE__,__LINE__,ROUTINE); \
-				_ADD_MEMBER(exImpl,m_addr); \
-				_ADD_MEMBER(exImpl,VAR); \
-				throw exImpl.getASErrorsEx(); \
-		}
+/** @#define _CATCH_ACS_EXCP_THROW_EX(IN_TYPE,OUT_TYPE,ROUTINE,VAR)
+*	Catch an ACS(with error trace) exception and launch a remote one (Ex).
+*	@param IN_TYPE the exception to catch 
+*	@param OUT_TYPE the exception to be launched 
+*	@param VAR variable name and value added as additional data 
+*	@param ROUTINE the calling routine 
+*/
+#define _CATCH_ACS_EXCP_THROW_EX(IN_TYPE, _ERR, ROUTINE, VAR)\
+catch(IN_TYPE& Ex)\
+{\
+	ASErrors::_ERR##ExImpl exImpl(Ex, __FILE__, __LINE__, ROUTINE);\
+	_ADD_MEMBER(exImpl, m_addr);\
+	_ADD_MEMBER(exImpl, VAR);\
+	throw exImpl.getASErrorsEx();\
+}
 		
- /** 	@#define _CATCH_EXCP_THROW_EX(IN_TYPE,OUT_TYPE,ROUTINE,VAR)
-     *  Catch an CORBA(w/o error trace) exception and launch a remote one (Ex).
-     *	@param IN_TYPE the exception to catch 
-     *	@param OUT_TYPE the exception to be launched 
-     *	@param VAR variable name and value added as addiotional data 
-     *	@param ROUTINE the calling routine 
-     */
-#define _CATCH_EXCP_THROW_EX(IN_TYPE,_ERR,ROUTINE,VAR) catch(IN_TYPE& Ex) { \
-				 ASErrors::_ERR##ExImpl exImpl(__FILE__,__LINE__,ROUTINE); \
-				_ADD_MEMBER(exImpl,m_addr); \
-				_ADD_MEMBER(exImpl,VAR); \
-				throw exImpl.getASErrorsEx(); \
-		}
+/** @#define _CATCH_EXCP_THROW_EX(IN_TYPE,OUT_TYPE,ROUTINE,VAR)
+*	Catch an CORBA(w/o error trace) exception and launch a remote one (Ex).
+*	@param IN_TYPE the exception to catch 
+*	@param OUT_TYPE the exception to be launched 
+*	@param VAR variable name and value added as addiotional data 
+*	@param ROUTINE the calling routine 
+*/
+#define _CATCH_EXCP_THROW_EX(IN_TYPE, _ERR, ROUTINE, VAR)\
+catch(IN_TYPE& Ex)\
+{\
+	ASErrors::_ERR##ExImpl exImpl(__FILE__, __LINE__, ROUTINE);\
+	_ADD_MEMBER(exImpl, m_addr);\
+	_ADD_MEMBER(exImpl, VAR);\
+	throw exImpl.getASErrorsEx();\
+}
+
 
 using namespace baci;
 using namespace maci;
 using namespace ASErrors;
 using namespace std;
-
 
 /**
 *	@mainpage USD component
@@ -271,109 +313,122 @@ using namespace std;
 */
 
 /**
- * This class USDImpl implements the single actuator of SRT AS.
- * It provides some asynchronous methods: up,down, stop, reset.
- * It also provides the property rappresenting some important characteristic.
-  * 
- * @author <a href=mailto:g.maccaferri@ira.cnr.it>Giuseppe Maccaferri</a>,
- * IRA, Bologna<br>
- * @version "@(#) $Id: usdImpl.h,v 1.1 2011-03-24 09:18:00 c.migoni Exp $"
- */
-class USDImpl: public CharacteristicComponentImpl,public virtual POA_ActiveSurface::USD
+* This class USDImpl implements the single actuator of SRT AS.
+* It provides some asynchronous methods: up,down, stop, reset.
+* It also provides the property rappresenting some important characteristic.
+* 
+* @author <a href=mailto:g.maccaferri@ira.cnr.it>Giuseppe Maccaferri</a>,
+* IRA, Bologna<br>
+* @version "@(#) $Id: usdImpl.h,v 1.1 2011-03-24 09:18:00 c.migoni Exp $"
+*/
+class USDImpl: public CharacteristicComponentImpl, public virtual POA_ActiveSurface::USD
 {
-	public:
-  
-     	/**
-     	* Constructor
-     	* @param poa Poa which will activate this and also all other components.
-     	* @param name component's name. This is also the name that will be used to find the
-     	* configuration data for the component in the Configuration Database.
-     	*/
-	USDImpl(const ACE_CString &, maci::ContainerServices* );
+public:
+	/**
+	* Constructor
+	* @param poa Poa which will activate this and also all other components.
+	* @param name component's name. This is also the name that will be used to find the
+	* configuration data for the component in the Configuration Database.
+	*/
+	USDImpl(const ACE_CString&, maci::ContainerServices*);
 
-    	/**
-     	* Destructor
-     	*/
-    	virtual ~USDImpl();
+	/**
+	* Destructor
+	*/
+	virtual ~USDImpl();
 	
-    	/*Override component lifecycle methods*/
-    	virtual void initialize() throw (ACSErr::ACSbaseExImpl);
-    	virtual void execute() throw (ACSErr::ACSbaseExImpl);
+	/* Override component lifecycle methods */
+	virtual void initialize() throw (ACSErr::ACSbaseExImpl);
+	virtual void execute() throw (ACSErr::ACSbaseExImpl);
 	virtual void cleanUp();
 	virtual void aboutToAbort();
 
+	void getStatus(CORBA::Long_out status);
+
 	/**
-     	* Following functions returns a reference to the property implementation of IDL interface 
-     	*/ 
-    	virtual ACS::RWlong_ptr delay() throw (CORBA::SystemException);
-    	virtual ACS::RWlong_ptr cmdPos() throw (CORBA::SystemException);
-    	virtual ACS::RWlong_ptr Fmin() throw (CORBA::SystemException);
-    	virtual ACS::RWlong_ptr Fmax() throw (CORBA::SystemException);
-    	virtual ACS::RWlong_ptr acc() throw (CORBA::SystemException);
-    	virtual ACS::RWlong_ptr uBits() throw (CORBA::SystemException);
-    	virtual ACS::RWdouble_ptr lmCorr() throw (CORBA::SystemException);
-    	virtual ACS::ROlong_ptr actPos() throw (CORBA::SystemException);
-    	virtual ACS::ROpattern_ptr status() throw (CORBA::SystemException);
-    	virtual ACS::ROlong_ptr softVer() throw (CORBA::SystemException);
-    	virtual ACS::ROlong_ptr type() throw (CORBA::SystemException);
-    	virtual ACS::RWdouble_ptr gravCorr() throw (CORBA::SystemException);
-    	virtual ACS::RWdouble_ptr userOffset() throw (CORBA::SystemException);
-	
+	* Following functions returns a reference to the property implementation of IDL interface 
+	*/ 
+	virtual ACS::RWlong_ptr delay() throw (CORBA::SystemException);
+	virtual ACS::RWlong_ptr cmdPos() throw (CORBA::SystemException);
+	virtual ACS::RWlong_ptr Fmin() throw (CORBA::SystemException);
+	virtual ACS::RWlong_ptr Fmax() throw (CORBA::SystemException);
+	virtual ACS::RWlong_ptr acc() throw (CORBA::SystemException);
+	virtual ACS::RWlong_ptr uBits() throw (CORBA::SystemException);
+	virtual ACS::RWdouble_ptr lmCorr() throw (CORBA::SystemException);
+	virtual ACS::ROlong_ptr actPos() throw (CORBA::SystemException);
+	virtual ACS::ROpattern_ptr status() throw (CORBA::SystemException);
+	virtual ACS::ROlong_ptr softVer() throw (CORBA::SystemException);
+	virtual ACS::ROlong_ptr type() throw (CORBA::SystemException);
+	virtual ACS::RWdouble_ptr gravCorr() throw (CORBA::SystemException);
+	virtual ACS::RWdouble_ptr userOffset() throw (CORBA::SystemException);
+
 	/**
-	* Implementation of unparametrized synchrnous methods
+	* Implementation of unparametrized synchronous methods
 	* There are the function that makes some typical operation with the actuator.
 	*/
-	void stop() throw (CORBA::SystemException, ASErrors::ASErrorsEx) { 	
-		try {
+	void stop() throw (CORBA::SystemException, ASErrors::ASErrorsEx)
+	{
+		try
+		{
 			action(STOP);
 		}
-		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::stop()",m_status)
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::stop()", m_status)
 	} 
-		
-	void up() throw (CORBA::SystemException,ASErrors::ASErrorsEx) {		
-		try {
-			action(GO,1,1);
+
+	void up() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+	{
+		try
+		{
+			action(GO, 1, 1);
 		}
-		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::up()",m_status)
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::up()", m_status)
 	} 
-		
-	void down() throw (CORBA::SystemException,ASErrors::ASErrorsEx) {  
-		try {
-			action(GO,-1,1);
+
+	void down() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+	{
+		try
+		{
+			action(GO, -1, 1);
 		}
-		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::down()",m_status)
-	} 
-	 
-	void reset() 	throw (CORBA::SystemException,ASErrors::ASErrorsEx);
-		 
-     	/**
-     	* upperMost() & bottomMost().Put the USD against the mechanical range limits (upper and lower).
-	* This intrinsecally makes the scale uncalibrated. 
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::down()", m_status)
+	}
+
+	void reset() throw (CORBA::SystemException,ASErrors::ASErrorsEx);
+
+	/**
+	* upperMost() & bottomMost().Put the USD against the mechanical range limits (upper and lower).
+	* This intrinsecally makes the scale uncalibrated.
 	* Be carefull to avoid mech. stress due to max diffs between adiacent nearest actuators
 	*/
-	void bottom() throw (CORBA::SystemException,ASErrors::ASErrorsEx) { 
-		try {
-			action(CPOS, m_bottom<<USxS,4);
+	void bottom() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+	{
+		try
+		{
+			action(CPOS, m_bottom<<USxS, 4);
 		}
-		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::bottom()",m_status)
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::bottom()", m_status)
 	}
-	void top() throw (CORBA::SystemException,ASErrors::ASErrorsEx) { 
-		try {
-			action(CPOS,m_top<<USxS,4);
+	void top() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+	{
+		try
+		{
+			action(CPOS, m_top<<USxS, 4);
 		}
-		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::top()",m_status)
-	} 
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::top()", m_status)
+	}
 
 	/**
 	* Implementation of move methods
 	* This function moves the actuator of incr step relative to actual position.
 	* @param incr Amount of increment in ustep.If negative the movement will be toward the bottom.
 	*/
-	void move(CORBA::Long incr) throw (CORBA::SystemException,ASErrors::ASErrorsEx) {	
-		try {
-			action(RPOS,incr<<USxS,4);
+	void move(CORBA::Long incr) throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+	{
+		try
+		{
+			action(RPOS, incr<<USxS, 4);
 		}
-		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::move()",m_status)
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::move()", m_status)
 	} 
 	
 	/**
@@ -383,11 +438,9 @@ class USDImpl: public CharacteristicComponentImpl,public virtual POA_ActiveSurfa
 	* For the best measure "stop by hardware" USD function is used.
 	* Then computes the len of camma zone, the central point and distance from uppermost edge.
 	* Finally move USD in camma central zone, load on USD counter the zeroRef value, moves the USD to 0 position and mark it as calibrated.
-	* @return 
 	*/
-	//virtual ACSErr::Completion* calibrate() throw (CORBA::SystemException,ASErrors::ASErrorsEx);
-	void calibrate() throw (CORBA::SystemException,ASErrors::ASErrorsEx);
-	
+	void calibrate() throw (CORBA::SystemException, ASErrors::ASErrorsEx);
+
 	/**
 	* Calibration verification. USD already must be already calibrated.
 	* This function moves the actuator to zero ref position and check the camma on status.
@@ -395,173 +448,179 @@ class USDImpl: public CharacteristicComponentImpl,public virtual POA_ActiveSurfa
 	* Adds half camma lenght and check the off status.
 	* Makes the same control on bottom edge.
 	* Be aware that other nearest usd are at middle scale, to avoid mechanical stresses
-	* @return 
 	*/
-	//virtual ACSErr::Completion* calVer() throw (CORBA::SystemException,ASErrors::ASErrorsEx) ;
-	void calVer() throw (CORBA::SystemException,ASErrors::ASErrorsEx);
+	void calVer() throw (CORBA::SystemException, ASErrors::ASErrorsEx);
 
 	/**
 	* Write calibration results on xml configuration file
 	*/
-	void writeCalibration(CORBA::Double_out cammaLenD, CORBA::Double_out cammaPosD, CORBA::Boolean_out calibrate) throw (CORBA::SystemException,ASErrors::ASErrorsEx);
+	void writeCalibration(CORBA::Double_out cammaLenD, CORBA::Double_out cammaPosD, CORBA::Boolean_out calibrate) throw (CORBA::SystemException, ASErrors::ASErrorsEx);
 
 	/**
 	* This function gets parameters useful for update function
 	*/
-	void posTable (const ACS::doubleSeq& theActuatorsCorrections, CORBA::Long theParPositions, CORBA::Double theDeltaEL, CORBA::Long theThreshold);
+	void posTable(const ACS::doubleSeq& theActuatorsCorrections, CORBA::Long theParPositions, CORBA::Double theDeltaEL, CORBA::Long theThreshold);
 			 
-     	/**
-     	* home. bring the USD to zero reference position.
-     	* This function moves the actuator to zero reference position, tipically at usd middlescale
-     	* @return 
+	/**
+	* home. bring the USD to zero reference position.
+	* This function moves the actuator to zero reference position, tipically at usd middlescale
 	*/
-	void refPos() throw (CORBA::SystemException,ASErrors::ASErrorsEx) {
-		try {
-			action(CPOS,0,4);
+	void refPos() throw (CORBA::SystemException, ASErrors::ASErrorsEx)
+	{
+		try
+		{
+			action(CPOS, 0, 4);
 		}
-		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::refPos()",m_status)
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::refPos()", m_status)
 	} 
 	 
-     	/**
-     	* setProfile().  Set the surface active profile.
-     	* @param prof	0 shaped, 1 parabolic, 2 parabolic fixed
+	/**
+	* setProfile().  Set the surface active profile.
+	* @param prof	0 shaped, 1 parabolic, 2 parabolic fixed
 	*/
-	void setProfile(CORBA::Long prof) throw (CORBA::SystemException,ASErrors::ASErrorsEx) {
+	void setProfile(CORBA::Long prof) throw (CORBA::SystemException, ASErrors::ASErrorsEx)
+	{
 		m_profile = prof;
 	} 
 	 
-     	/**
-     	* correction().The last minute coorection to be applied.
-     	* They will be added to actual computed USD position
-     	* @param corr	the correction in mm 
-     	*/
-	void correction(CORBA::Double corr) throw (CORBA::SystemException,ASErrors::ASErrorsEx) {
+	/**
+	* correction().The last minute coorection to be applied.
+	* They will be added to actual computed USD position
+	* @param corr	the correction in mm 
+	*/
+	void correction(CORBA::Double corr) throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+	{
 		ACSErr::Completion_var comp;
-		try {
+		try
+		{
 			comp = lmCorr()->set_sync(corr);
 		}
 		catch (CORBA::SystemException& Ex) 
 		{
-			ACS_SHORT_LOG((LM_CRITICAL, "CORBA::SystemException thrown! "));
+			ACS_SHORT_LOG((LM_CRITICAL, "CORBA::SystemException thrown!"));
 		}
-	} 
+	}
 
-     	/**
-     	* update(). Applay the antenna elevation dependant corrections.
-     	* They are the gravity and user-offset
-     	* @param elevation	antenna elevation in degrees. 
-     	*/
-	void update(CORBA::Double elevation) throw (CORBA::SystemException,ASErrors::ASErrorsEx);
+	/**
+	* update(). Applay the antenna elevation dependant corrections.
+	* They are the gravity and user-offset
+	* @param elevation	antenna elevation in degrees. 
+	*/
+	void update(CORBA::Double elevation) throw (CORBA::SystemException, ASErrors::ASErrorsEx);
 
-     	/**
-     	* stow() & setup(). General management functions.
+	/**
+	* stow() & setup(). General management functions.
 	* stow: Stop the USD position loop control and bring it to bottom most position (full closed).
 	* setup: bring the usd to zeroRef position and starts the pos. control loop
 	*/
-	void stow() throw (CORBA::SystemException,ASErrors::ASErrorsEx) {
-		try {
-                	action(STOP);
-                }
-                _CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::stow()",m_status)
-			 
-                try {
-                	action(CPOS, m_bottom<<USxS,4);
-                }
-                _CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::stow()",m_status)
-                 
-	}
-	void setup() throw (CORBA::SystemException,ASErrors::ASErrorsEx) { 
-		try {
+	void stow() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+	{
+		try
+		{
 			action(STOP);
-                }
-                _CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::setup()",m_status)
-				
-                try {
-                    action(CPOS,0,4);
-                }
-                _CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::setup()",m_status)
+		}
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::stow()", m_status)
+			 
+		try
+		{
+			action(CPOS, m_bottom<<USxS, 4);
+		}
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::stow()", m_status)
+				 
+	}
+	void setup() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+	{
+		try
+		{
+			action(STOP);
+		}
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::setup()", m_status)
+
+		try
+		{
+			action(CPOS, 0, 4);
+		}
+		_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::setup()", m_status)
 	}
 
 	/**
-     	* check a corba exception.
-     	* Convert a CORBA exception in  C++ exception and check it.
-     	* @param Ex CORBA exception.
-    	*/
+	* check a corba exception.
+	* Convert a CORBA exception in  C++ exception and check it.
+	* @param Ex CORBA exception.
+	*/
 	void exCheck(ASErrors::ASErrorsEx Ex);
 
-     	/**
-     	* Check a CORBA completion passed by reference.
-     	* Convert an error completion in  C++ exception and log it.
-     	* @param comp completion.
-     	* @return true if comp is an error completion else false
-    	*/
-	bool compCheck(ACSErr::CompletionImpl& );
+	/**
+	* Check a CORBA completion passed by reference.
+	* Convert an error completion in  C++ exception and log it.
+	* @param comp completion.
+	* @return true if comp is an error completion else false
+	*/
+	bool compCheck(ACSErr::CompletionImpl&);
 
-    	/** 
-    	* this counts the consecutive times the USD does not respond
-    	*/
+	/**
+	* this counts the consecutive times the USD does not respond
+	*/
 	int m_failures;
 
-    	/** 
-    	* flag rappresenting the availability of the module.
-    	* It is available if is comunicating. After five times USD doesn't respond, the flag is set to FALSE to inhibit any further activity.
-    	*/	
+	/** 
+	* flag rappresenting the availability of the module.
+	* It is available if is comunicating. After five times USD doesn't respond, the flag is set to FALSE to inhibit any further activity.
+	*/	
 	bool m_available;
 
-    	/** 
-    	* stepper motor positioning resolution (step)
-    	*/	
+	/** 
+	* stepper motor positioning resolution (step)
+	*/	
 	double m_step_res;
 
 	/** 
-    	* calibrate flag
-    	*/	
+	* calibrate flag
+	*/	
 	BYTE m_calibrate;
 
 	/** 
-    	* position loop on
-    	*/	
+	* position loop on
+	*/	
 	BYTE m_ploop;
 
-	private:
-
+private:
 	CORBA::Long m_profile;
    	/**
-    	* pointer to LAN/485 component
-    	*/
-	//MOD_LAN::lan* m_pLan;
+	* pointer to LAN/485 component
+	*/
 	ActiveSurface::lan* m_pLan;
 	
 	/** 
-    	* sector of usd
-    	*/	
+	* sector of usd
+	*/	
 	BYTE m_sector;
 
-    	/**
-    	* lan address of usd. 
-    	* Each lan rappresent a radius. Looking frontally at parabola, the first start from north and the other follow in cw mode.
-    	*/	
+	/**
+	* lan address of usd. 
+	* Each lan rappresent a radius. Looking frontally at parabola, the first start from north and the other follow in cw mode.
+	*/	
 	BYTE m_lanNum;
 
-    	/** 
-    	* serial address of usd
-    	*/	
+	/** 
+	* serial address of usd
+	*/	
 	BYTE m_addr;
 
 	/** 
-    	* camma lenght in step
-    	*/	
+	* camma lenght in step
+	*/	
 	int m_cammaLen;
 
 	/**
-    	* camma position in step
-    	*/
+	* camma position in step
+	*/
 	int m_cammaPos;
 
 	/**
-    	* camma end in step
-    	*/
-        int m_cammaEnd;
+	* camma end in step
+	*/
+	int m_cammaEnd;
 
 	/**
 	* array of actuator corrections
@@ -586,67 +645,67 @@ class USDImpl: public CharacteristicComponentImpl,public virtual POA_ActiveSurfa
 	*/
 	int m_lastCmdStep;
 
-    	/**
-    	* usefull range in step
-    	*/
+	/**
+	* usefull range in step
+	*/
 	int m_fullRange;
 
-    	/**                                      
-    	* zero offset
-    	*/
+	/**
+	* zero offset
+	*/
 	int m_zeroRef;
 
 	/** 
-    	* step x turn (step)
-    	*/	
+	* step x turn (step)
+	*/	
 	int m_step_giro;
 
 	/** 
-    	* step resolution (1/2^rs) pag 7 manuale USD
-    	*/	
+	* step resolution (1/2^rs) pag 7 manuale USD
+	*/	
 	BYTE m_rs;
 
 	/**
 	* step to deg conversion factor
-    	*/
+	*/
 	double m_step2deg;
 
-    	/**
-    	* top position (step)
-    	*/
-	int m_top;
-
-    	/**
-    	* bottom position (step)
-    	*/
-	int m_bottom;
+	/**
+	* top position (step)
+	*/
+	long m_top;
 
 	/**
-    	* status bytes
-    	*/
+	* bottom position (step)
+	*/
+	long m_bottom;
+
+	/**
+	* status bytes
+	*/
 	int m_status;
 
-     	/**
-     	* Check if USD motor is still running after given psition
+ 	/**
+ 	* Check if USD motor is still running after given psition
 	* The required time is computed from position displacement and Fmax value,
 	* plus some safety seconds.
 	* @param allowed secs for motion.
-     	* @return true if still running 0 if stopped.
-    	*/
+ 	* @return true if still running 0 if stopped.
+	*/
 	bool stillRunning(long pos) throw (ASErrors::ASErrorsExImpl);
 	
-     	/**
-     	* Check calibration comparing quote and cal status
+ 	/**
+ 	* Check calibration comparing quote and cal status
 	* Must be used only when not running
-     	* @return true if calibrated 0 if not.
-    	*/
+ 	* @return true if calibrated 0 if not.
+	*/
 	bool chkCal() throw (ASErrors::ASErrorsExImpl);
 	
 	/**
-     	* Check the thrown exception and logging it.
-     	* Basing on  thrown C++ exception, it set to FALSE the m_available flag to inhibit any further activity 
-     	* @param exImpl C++ exception.
-    	*/
+ 	* Check the thrown exception and logging it.
+ 	* Basing on  thrown C++ exception, it set to FALSE the m_available flag to inhibit any further activity 
+ 	* @param exImpl C++ exception.
+	*/
 	void exImplCheck(ASErrors::ASErrorsExImpl);
 
   	/**
@@ -655,16 +714,16 @@ class USDImpl: public CharacteristicComponentImpl,public virtual POA_ActiveSurfa
 	* @param parameter an otional parameter for the command
 	* @param nbytes lenght in bytes of parameter
 	*/
-	void action( int cmd,int parameter=0,int nbytes=0) throw (ASErrors::ASErrorsExImpl);
+	void action(int cmd, int parameter=0, int nbytes=0) throw (ASErrors::ASErrorsExImpl);
 
 	/**
 	* ALMA C++ coding standards state copy operators should be disabled.
-     	*/
-    	void operator=(const USDImpl&);
+	*/
+	void operator=(const USDImpl&);
  
  	/**
-     	* cob name of the LAN component.
-     	*/
+	* cob name of the LAN component.
+	*/
  	IRA::CString lanCobName;
 	
 	/**
@@ -672,20 +731,20 @@ class USDImpl: public CharacteristicComponentImpl,public virtual POA_ActiveSurfa
 	*/
 	ContainerServices* cs;
 
-  	protected:
-    	SmartPropertyPointer<RWlong> m_delay_sp;
-    	SmartPropertyPointer<RWlong> m_cmdPos_sp;
-    	SmartPropertyPointer<RWlong> m_Fmin_sp;
-    	SmartPropertyPointer<RWlong> m_Fmax_sp;
-    	SmartPropertyPointer<RWlong> m_acc_sp;
-    	SmartPropertyPointer<RWlong> m_uBits_sp;
-    	SmartPropertyPointer<RWdouble> m_lmCorr_sp;
-    	SmartPropertyPointer<ROlong> m_actPos_sp;
-    	SmartPropertyPointer<ROpattern> m_status_sp;
-    	SmartPropertyPointer<ROlong> m_softVer_sp;
-    	SmartPropertyPointer<ROlong> m_type_sp;
-    	SmartPropertyPointer<RWdouble> m_gravCorr_sp;
-    	SmartPropertyPointer<RWdouble> m_userOffset_sp;
+protected:
+	SmartPropertyPointer<RWlong> m_delay_sp;
+	SmartPropertyPointer<RWlong> m_cmdPos_sp;
+	SmartPropertyPointer<RWlong> m_Fmin_sp;
+	SmartPropertyPointer<RWlong> m_Fmax_sp;
+	SmartPropertyPointer<RWlong> m_acc_sp;
+	SmartPropertyPointer<RWlong> m_uBits_sp;
+	SmartPropertyPointer<RWdouble> m_lmCorr_sp;
+	SmartPropertyPointer<ROlong> m_actPos_sp;
+	SmartPropertyPointer<ROpattern> m_status_sp;
+	SmartPropertyPointer<ROlong> m_softVer_sp;
+	SmartPropertyPointer<ROlong> m_type_sp;
+	SmartPropertyPointer<RWdouble> m_gravCorr_sp;
+	SmartPropertyPointer<RWdouble> m_userOffset_sp;
 };
 
 #endif /*!USDImpl_H*/

--- a/SRT/Servers/SRTActiveSurfaceUSDServer/src/usdImpl.cpp
+++ b/SRT/Servers/SRTActiveSurfaceUSDServer/src/usdImpl.cpp
@@ -3,51 +3,52 @@
 #include <maciContainerImpl.h>
 #include <usdDevIO.i>
 
-/*******************************************************************************
-*
-* "@(#) $Id: usdImpl.cpp,v 1.1 2011-03-24 09:18:26 c.migoni Exp $"
-*
-* who       when      what
-* --------  --------  ----------------------------------------------
-* GMM       jul 2005  creation				   
-* GMM 	    sep 2006  ACS 5.0.3 adaptions
-* CM	    jan 2013  ACS 8.0.1 adaptions
-* CM	    jan 2013  All code revised and adapted to be used from SRTActiveSurfaceBoss component
-* CM	    jan 2013  debugged calibrate() and calVer() routines
-* CM	    jan 2013  cammaLen and cammaPos parameters are now saved as degrees in xml files (more useful to check)
-*/
+/************************************************************************************************************************/
+/* "@(#) $Id: usdImpl.cpp,v 1.1 2011-03-24 09:18:26 c.migoni Exp $"														*/
+/*																														*/
+/* who		when		what																							*/
+/* --------	--------	----------------------------------------------													*/
+/* GMM		jul 2005	creation																						*/
+/* GMM		sep 2006	ACS 5.0.3 adaptions																				*/
+/* CM		jan 2013	ACS 8.0.1 adaptions																				*/
+/* CM		jan 2013	All code revised and adapted to be used from SRTActiveSurfaceBoss component						*/
+/* CM		jan 2013	debugged calibrate() and calVer() routines														*/
+/* CM		jan 2013	cammaLen and cammaPos parameters are now saved as degrees in xml files (more useful to check)	*/
+/* GC		oct 2019	added check in order to avoid commanding several times the same position						*/
+/* GC		nov 2019	added the getStatus method and reviewed indentation												*/
+/************************************************************************************************************************/
 
 using namespace maci;
 
 USDImpl::USDImpl(const ACE_CString& CompName, maci::ContainerServices* containerServices) : 
-	CharacteristicComponentImpl(CompName,containerServices),
-	m_pLan(ActiveSurface::lan::_nil()),
-    	//m_pLan(MOD_LAN::lan::_nil()),
-	m_delay_sp(this),
-    	m_cmdPos_sp(this),
-    	m_Fmin_sp(this),
-    	m_Fmax_sp(this),
-    	m_acc_sp(this),
-    	m_uBits_sp(this),
-    	m_lmCorr_sp(this),
-    	m_actPos_sp(this),
-    	m_status_sp(this),
-    	m_softVer_sp(this),
-    	m_type_sp(this),
-    	m_gravCorr_sp(this),
-    	m_userOffset_sp(this)	
+		CharacteristicComponentImpl(CompName,containerServices),
+		m_available(false),
+		m_pLan(ActiveSurface::lan::_nil()),
+		actuatorsCorrections(NULL),
+		elevations(NULL),
+		m_status(0),
+		m_delay_sp(this),
+		m_cmdPos_sp(this),
+		m_Fmin_sp(this),
+		m_Fmax_sp(this),
+		m_acc_sp(this),
+		m_uBits_sp(this),
+		m_lmCorr_sp(this),
+		m_actPos_sp(this),
+		m_status_sp(this),
+		m_softVer_sp(this),
+		m_type_sp(this),
+		m_gravCorr_sp(this),
+		m_userOffset_sp(this)
 { 
 	ACS_SHORT_LOG((LM_INFO,"::USDImpl::USDImpl: constructor;Constructor!"));
-	actuatorsCorrections = NULL;
-	elevations = NULL;
 }
 
 void USDImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 {
 	cs = getContainerServices();
-	ACSErr::Completion_var cp_sp;
-	
-	if (CIRATools::getDBValue(cs,"sector",(long&)m_sector) &&
+
+	if(CIRATools::getDBValue(cs,"sector",(long&)m_sector) &&
 		CIRATools::getDBValue(cs,"lan",(long&)m_lanNum) &&
 		CIRATools::getDBValue(cs,"serialAddress",(long&)m_addr) &&
 		CIRATools::getDBValue(cs,"fullRange",(long&)m_fullRange) &&
@@ -59,6 +60,12 @@ void USDImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 		CIRATools::getDBValue(cs,"calibrate",(long&)m_calibrate))
 	{
 		ACS_SHORT_LOG((LM_INFO,"USD%d: CDB parameter read",m_addr));
+
+		m_step2deg = (double)(360. / m_step_giro);
+		m_step_res = (double)(1. / pow(2, m_rs));
+		m_top = -m_zeroRef;
+		m_bottom = m_fullRange-m_zeroRef;
+		m_lastCmdStep = m_top + 1; // a value outside of full range will never be commanded, so the next commanded position will for sure be different
 	}
 	else
 	{
@@ -66,24 +73,17 @@ void USDImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 		ASErrors::CDBAccessErrorExImpl exImpl(__FILE__,__LINE__,"USDImpl::initialize() - Error reading CDB parameters");
 		throw acsErrTypeLifeCycle::LifeCycleExImpl(exImpl,__FILE__,__LINE__,"USDImpl::initialize()");
 	}
-	m_lastCmdStep = 30000; // a value outside of range -21000/+21000 will never be commanded, so the next commanded position will for sure be different
-	m_step2deg=(double)(360./m_step_giro);
-	m_step_res=(double)(1./pow(2,m_rs));
-	m_top=-m_zeroRef;
-	m_fullRange = -42000; // TBD: devo impostarlo "manualmente" perche' lo legge male dal CDB !!!
-	m_bottom=m_fullRange-m_zeroRef;
 
-	//printf("m_fullRange = %d, m_zeroRef = %d, m_bottom = %d\n", m_fullRange, m_zeroRef, m_bottom);
-
-        // Activate the LAN component	
-	lanCobName.Format("AS/SECTOR%02d/LAN%02d",m_sector,m_lanNum);
+	// Activate the LAN component
+	lanCobName.Format("AS/SECTOR%02d/LAN%02d", m_sector, m_lanNum);
 	
 	// Use container to activate the object
-	ACS_SHORT_LOG((LM_INFO, "Getting component: %s", (const char*)lanCobName) );
-	//MOD_LAN::lan_var obj=MOD_LAN::lan::_nil();
+	ACS_SHORT_LOG((LM_INFO, "Getting component: %s", (const char*)lanCobName));
 	ActiveSurface::lan_var obj=ActiveSurface::lan::_nil();
-	try {
-		obj=cs->getComponent<ActiveSurface::lan>((const char *)lanCobName);
+	try
+	{
+		obj = cs->getComponent<ActiveSurface::lan>((const char *)lanCobName);
+		m_pLan = ActiveSurface::lan::_narrow(obj.in());
 	}
 	catch (maciErrType::CannotGetComponentExImpl)
 	{	
@@ -91,9 +91,6 @@ void USDImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 		ASErrors::CannotGetUSDExImpl exImpl(__FILE__,__LINE__,"USDImpl::initialize()");
 		throw acsErrTypeLifeCycle::LifeCycleExImpl(exImpl,__FILE__,__LINE__,"USDImpl::initialize()");
 	}
-	
-	//m_pLan = MOD_LAN::lan::_narrow(obj.in());
-	m_pLan = ActiveSurface::lan::_narrow(obj.in());
 	ACS_SHORT_LOG((LM_INFO,"lan linked!"));
 
 	m_available = true;
@@ -102,39 +99,43 @@ void USDImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 	ACE_CString CompName(this->name());
 	
 	ACS_SHORT_LOG((LM_INFO,"Property creation..."));
-	try {
-		m_delay_sp = new RWlong(CompName+":delay",getComponent(),new USDDevIO<CORBA::Long>(this,m_pLan,m_addr,DELAY,1,0),true);
-    		m_Fmin_sp=new RWlong(CompName+":Fmin",getComponent(),new USDDevIO<CORBA::Long>(this,m_pLan,m_addr,FMIN,2,0),true);
-    		m_Fmax_sp=new RWlong(CompName+":Fmax",getComponent(),new USDDevIO<CORBA::Long>(this,m_pLan,m_addr,FMAX,2,0),true);
-    		m_acc_sp=new RWlong(CompName+":acc",getComponent(),new USDDevIO<CORBA::Long>(this,m_pLan,m_addr,ACCL,1,0),true);
-        	m_uBits_sp=new RWlong(CompName+":uBits",getComponent(),new USDDevIO<CORBA::Long>(this,m_pLan,m_addr,UBIT,1,0),true);
-    		m_actPos_sp=new ROlong(CompName+":actPos",getComponent(),new USDDevIO<CORBA::Long>(this,m_pLan,m_addr,APOS,0,4),true);
-    		m_status_sp=new ROpattern(CompName+":status",getComponent(),new USDDevIO<ACS::pattern>(this,m_pLan,m_addr,STAT,0,3),true);
-    		m_softVer_sp=new ROlong(CompName+":softVer",getComponent(),new USDDevIO<CORBA::Long>(this,m_pLan,m_addr,SVER,0,1),true);
-    		m_type_sp=new ROlong(CompName+":type",getComponent(),new USDDevIO<CORBA::Long>(this,m_pLan,m_addr,USDT,0,1),true);
-		m_cmdPos_sp= new RWlong(CompName+":cmdPos",getComponent(),new USDDevIO<CORBA::Long>(this,m_pLan,m_addr,CPOS,4,0),true);
-		m_gravCorr_sp=new  RWdouble(CompName+":gravCorr",getComponent());
-		m_lmCorr_sp=new  RWdouble(CompName+":lmCorr",getComponent()); 
-		m_userOffset_sp=new  RWdouble(CompName+":userOffset",getComponent());
+	try
+	{
+		m_delay_sp		= new RWlong(CompName + ":delay", getComponent(), new USDDevIO<CORBA::Long>(this, m_pLan, m_addr, DELAY, 1, 0), true);
+		m_Fmin_sp		= new RWlong(CompName + ":Fmin", getComponent(), new USDDevIO<CORBA::Long>(this, m_pLan, m_addr, FMIN, 2, 0), true);
+		m_Fmax_sp		= new RWlong(CompName + ":Fmax", getComponent(), new USDDevIO<CORBA::Long>(this, m_pLan, m_addr, FMAX, 2, 0), true);
+		m_acc_sp		= new RWlong(CompName + ":acc", getComponent(), new USDDevIO<CORBA::Long>(this, m_pLan, m_addr, ACCL, 1, 0), true);
+		m_uBits_sp		= new RWlong(CompName + ":uBits", getComponent(), new USDDevIO<CORBA::Long>(this, m_pLan, m_addr, UBIT, 1, 0), true);
+		m_actPos_sp		= new ROlong(CompName + ":actPos", getComponent(), new USDDevIO<CORBA::Long>(this, m_pLan, m_addr, APOS, 0, 4), true);
+		m_softVer_sp	= new ROlong(CompName + ":softVer", getComponent(), new USDDevIO<CORBA::Long>(this, m_pLan, m_addr, SVER, 0, 1), true);
+		m_type_sp		= new ROlong(CompName + ":type", getComponent(), new USDDevIO<CORBA::Long>(this, m_pLan, m_addr, USDT, 0, 1), true);
+		m_cmdPos_sp		= new RWlong(CompName + ":cmdPos", getComponent(), new USDDevIO<CORBA::Long>(this, m_pLan, m_addr, CPOS, 4, 0), true);
+		m_status_sp		= new ROpattern(CompName + ":status", getComponent(), new USDDevIO<ACS::pattern>(this, m_pLan, m_addr, STAT, 0, 3), true);
+		m_gravCorr_sp	= new RWdouble(CompName + ":gravCorr", getComponent());
+		m_lmCorr_sp		= new RWdouble(CompName + ":lmCorr", getComponent());
+		m_userOffset_sp = new RWdouble(CompName + ":userOffset", getComponent());
 	}
 	catch (ASErrors::ASErrorsExImpl ex)
 	{
 		_THROW_EXCPT_FROM_EXCPT(acsErrTypeLifeCycle::LifeCycleExImpl,ex,"usdImpl::initialize()")
 	}
-	
-	try {
-		stop();			// terminate any ongoing movement
+
+	try
+	{
+		stop(); // terminate any ongoing movement
 		_GET_PROP(status,m_status,"usdImpl::initialize()")
-		if(!(m_calibrate && m_status&ENBL)) {
-            		reset(); // load the default params.
+		if(!(m_calibrate && m_status&ENBL))
+		{
+			reset(); // load the default params.
 		}
-		else {
+		else
+		{
 			//* restore defaults *//
-        		_SET_LDEF(delay,"USDImpl::reset()");
-    			_SET_LDEF(Fmax,"USDImpl::reset()");
-    			_SET_LDEF(Fmin,"USDImpl::reset()");
-    			_SET_LDEF(acc,"USDImpl::reset()");
-			_SET_LDEF(uBits,"USDImpl::reset()");
+			_SET_LDEF(delay, "USDImpl::initialize()");
+			_SET_LDEF(Fmax,  "USDImpl::initialize()");
+			_SET_LDEF(Fmin,  "USDImpl::initialize()");
+			_SET_LDEF(acc,   "USDImpl::initialize()");
+			_SET_LDEF(uBits, "USDImpl::initialize()");
 		}
 	}
 	catch (ASErrors::ASErrorsEx& ex)
@@ -147,7 +148,7 @@ void USDImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 	}
 	catch (...)
 	{
-		ACS_DEBUG("::usdImpl::initialize","Not captuerd exception!"); 
+		ACS_DEBUG("::usdImpl::initialize", "Unknown exception!");
 	}
 }
 
@@ -181,18 +182,18 @@ void USDImpl::execute() throw (ACSErr::ACSbaseExImpl)
 	ACS_SHORT_LOG((LM_INFO,"Property creation..."));
 	try {
 		m_delay_sp = new RWlong(CompName+":delay",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,DELAY,1,0),true);
-    	m_Fmin_sp=new RWlong(CompName+":Fmin",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,FMIN,2,0),true);
-    	m_Fmax_sp=new RWlong(CompName+":Fmax",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,FMAX,2,0),true);
-    	m_acc_sp=new RWlong(CompName+":acc",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,ACCL,1,0),true);
-        m_uBits_sp=new RWlong(CompName+":uBits",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,UBIT,1,0),true);
-    	m_actPos_sp=new ROlong(CompName+":actPos",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,APOS,0,4),true);
-    	m_status_sp=new ROpattern(CompName+":status",getComponent(),new USDDevIO<ACS::pattern>(this,m_pLan,m_addr,STAT,0,3),true);
-    	m_softVer_sp=new ROlong(CompName+":softVer",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,SVER,0,1),true);
-    	m_type_sp=new ROlong(CompName+":type",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,USDT,0,1),true);
-    	m_cmdPos_sp= new RWlong(CompName+":cmdPos",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,CPOS,4,0),true);
-    	m_gravCorr_sp=new  RWdouble(CompName+":gravCorr",getComponent());
-    	m_lmCorr_sp=new  RWdouble(CompName+":lmCorr",getComponent()); 
-    	m_userOffset_sp=new  RWdouble(CompName+":userOffset",getComponent());
+		m_Fmin_sp=new RWlong(CompName+":Fmin",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,FMIN,2,0),true);
+		m_Fmax_sp=new RWlong(CompName+":Fmax",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,FMAX,2,0),true);
+		m_acc_sp=new RWlong(CompName+":acc",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,ACCL,1,0),true);
+		m_uBits_sp=new RWlong(CompName+":uBits",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,UBIT,1,0),true);
+		m_actPos_sp=new ROlong(CompName+":actPos",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,APOS,0,4),true);
+		m_status_sp=new ROpattern(CompName+":status",getComponent(),new USDDevIO<ACS::pattern>(this,m_pLan,m_addr,STAT,0,3),true);
+		m_softVer_sp=new ROlong(CompName+":softVer",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,SVER,0,1),true);
+		m_type_sp=new ROlong(CompName+":type",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,USDT,0,1),true);
+		m_cmdPos_sp= new RWlong(CompName+":cmdPos",getComponent(),new USDDevIO<Long>(this,m_pLan,m_addr,CPOS,4,0),true);
+		m_gravCorr_sp=new  RWdouble(CompName+":gravCorr",getComponent());
+		m_lmCorr_sp=new  RWdouble(CompName+":lmCorr",getComponent());
+		m_userOffset_sp=new  RWdouble(CompName+":userOffset",getComponent());
 	}
 	catch (ASErrors::ASErrorsExImpl ex)
 	{
@@ -201,16 +202,16 @@ void USDImpl::execute() throw (ACSErr::ACSbaseExImpl)
 	
 	try {
 		stop();			// terminate any ongoing movement
-        printf("calibrate = %d\n", m_calibrate);
-        printf("ENBL      = %d\n", m_status&ENBL);
+		printf("calibrate = %d\n", m_calibrate);
+		printf("ENBL	  = %d\n", m_status&ENBL);
 		_GET_PROP(status,m_status,"usdImpl::initialize()")
-        printf("calibrate = %d\n", m_calibrate);
-        printf("ENBL      = %d\n", m_status&ENBL);
+		printf("calibrate = %d\n", m_calibrate);
+		printf("ENBL	  = %d\n", m_status&ENBL);
 		if(!(m_calibrate && m_status&ENBL)) {
-            reset(); // load the default params.
-            printf("calibrate = %d\n", m_calibrate);
-            printf("ENBL      = %d\n", m_status&ENBL);
-        }
+			reset(); // load the default params.
+			printf("calibrate = %d\n", m_calibrate);
+			printf("ENBL	  = %d\n", m_status&ENBL);
+		}
 	}
 	catch (ASErrors::ASErrorsEx& ex)
 	{
@@ -224,14 +225,14 @@ void USDImpl::execute() throw (ACSErr::ACSbaseExImpl)
 	{
 		ACS_DEBUG("::usdImpl::initialize","Not captuerd exception!"); 
 	}
-    ////////////////////////////////////////// 22 giugno 2009
+	////////////////////////////////////////// 22 giugno 2009
 	//_SET_PROP(Fmax,250,"usdImpl::calibrate()")
-    ////////////////////////////////////////// calibration test; by CM
-    printf ("RS0        in execute = %d\n", m_status&0x000001);
-    printf ("RS1        in execute = %d\n", m_status&0x000002);
-    printf ("RS2        in execute = %d\n", m_status&0x000004);
-    printf ("resolution in execute = %d\n", m_status&0x000008);
-    printf ("m_rs in initialize    = %d\n", m_rs);
+	////////////////////////////////////////// calibration test; by CM
+	printf ("RS0		in execute = %d\n", m_status&0x000001);
+	printf ("RS1		in execute = %d\n", m_status&0x000002);
+	printf ("RS2		in execute = %d\n", m_status&0x000004);
+	printf ("resolution in execute = %d\n", m_status&0x000008);
+	printf ("m_rs in initialize	= %d\n", m_rs);
 */
 
 	ACS_SHORT_LOG((LM_INFO,"::USDImpl::execute(): USD component ready!"));
@@ -246,7 +247,8 @@ void USDImpl::cleanUp()
 	if(CORBA::is_nil(m_pLan) == false)
 	{
 		ACS_LOG(LM_RUNTIME_CONTEXT, "::USDImpl::cleanUp",(LM_DEBUG, "Releasing LANx"));
-		try {
+		try
+		{
 			cs->releaseComponent((const char*)lanCobName);
 		}
 		
@@ -254,20 +256,20 @@ void USDImpl::cleanUp()
 		{
 			ACS_SHORT_LOG((LM_INFO, "cannot release lan component %s", (const char*)lanCobName));
 		}
-		 // be sure to set the reference to nil
-		 //m_pLan = MOD_LAN::lan::_nil();
+		// be sure to set the reference to nil
+		//m_pLan = MOD_LAN::lan::_nil();
 		 m_pLan = ActiveSurface::lan::_nil();
 	}
 
-    if(actuatorsCorrections != NULL)
-    {
-        delete [] actuatorsCorrections;
-    }
+	if(actuatorsCorrections != NULL)
+	{
+		delete [] actuatorsCorrections;
+	}
 
-    if(elevations != NULL)
-    {
-        delete [] elevations;
-    }
+	if(elevations != NULL)
+	{
+		delete [] elevations;
+	}
 }
 
  
@@ -275,7 +277,8 @@ void USDImpl::aboutToAbort()
 {
 	ACS_TRACE("::USDImpl::aboutToAbort()");
 
-	try {
+	try
+	{
 		cs->releaseComponent((const char*)lanCobName);
 	}
 	catch (maciErrType::CannotReleaseComponentExImpl)
@@ -287,336 +290,299 @@ void USDImpl::aboutToAbort()
 	//m_pLan = MOD_LAN::lan::_nil();
 	m_pLan = ActiveSurface::lan::_nil();
 
-    if(actuatorsCorrections != NULL)
-    {
-        delete [] actuatorsCorrections;
-    }
+	if(actuatorsCorrections != NULL)
+	{
+		delete [] actuatorsCorrections;
+	}
 
-    if(elevations != NULL)
-    {
-        delete [] elevations;
-    }
+	if(elevations != NULL)
+	{
+		delete [] elevations;
+	}
 }
 
-void USDImpl::reset() 	throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+void USDImpl::getStatus(int& status)
+{
+	status = m_status;
+}
+
+void USDImpl::reset() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
 { 
 	ACS_TRACE("::USDImpl::reset()");
-	
+
 	m_calibrate = 0;
 	
-  	try {
-        	_SET_CDB(calibrate,m_calibrate,"::USDImpl::reset()")
-        	action(RESET);
+	try
+	{
+		_SET_CDB(calibrate, m_calibrate, "::USDImpl::reset()")
+		action(RESET);
 
-        	//* restore defaults *//
-        	_SET_LDEF(delay,"USDImpl::reset()");
-    		_SET_LDEF(Fmax,"USDImpl::reset()");
-    		_SET_LDEF(Fmin,"USDImpl::reset()");
-    		_SET_LDEF(acc,"USDImpl::reset()");
-    		_SET_LDEF(uBits,"USDImpl::reset()");
+		//* restore defaults *//
+		_SET_LDEF(delay, "USDImpl::reset()");
+		_SET_LDEF(Fmax,  "USDImpl::reset()");
+		_SET_LDEF(Fmin,  "USDImpl::reset()");
+		_SET_LDEF(acc,   "USDImpl::reset()");
+		_SET_LDEF(uBits, "USDImpl::reset()");
 
-    		action(RESL,m_rs,1);			// resolution
+		action(RESL, m_rs, 1); // resolution
 	}
-  
-  	_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"USDImpl::reset()",m_addr)
-        
-	ACS_SHORT_LOG((LM_WARNING,"USD %d resetted and initialized!",m_addr));
 
-} //  reset()
+	_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "USDImpl::reset()", m_addr)
 
-//ACSErr::Completion* USDImpl::calibrate() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+	ACS_SHORT_LOG((LM_WARNING, "USD %d resetted and initialized!", m_addr));
+}
+
 void USDImpl::calibrate() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
 {
 	ACS_TRACE("::USDImpl::calibrate()");
 
-	ACSErr::Completion_var cp_sp; 
-	int ifp=0;
-	long cammaBegin=0, cammaEnd=0;
-	//double cammaLenD, cammaPosD;
-		
-	m_calibrate=false;
-	m_cammaLen=m_cammaPos=-1;
-	
-	//_SET_CDB(calibrate,m_calibrate,"::usdImpl::calibrate");
+	int ifp = 0;
+	long cammaBegin = 0, cammaEnd = 0;
 
-	try {
+	m_calibrate = false;
+	m_cammaLen = m_cammaPos = -1;
+
+	try
+	{
 		action(STOP);
-		ACS_DEBUG("::usdImpl::calibrate","stopped!");
+		ACS_DEBUG("::usdImpl::calibrate", "stopped!");
 
-		CIRATools::Wait(1,0); // 1 sec
-		action(LCNTR,m_step_giro<<USxS,4); // load the counter with know value
-		ACS_DEBUG_PARAM("::usdImpl::calibrate","Loaded %d on counter",m_step_giro);
+		CIRATools::Wait(1, 0); // 1 sec
+		action(LCNTR, m_step_giro<<USxS, 4); // load the counter with know value
+		ACS_DEBUG_PARAM("::usdImpl::calibrate", "Loaded %d on counter", m_step_giro);
 
-		_SET_PROP(Fmax,100,"usdImpl::calibrate()")
-		ACS_DEBUG_PARAM("::usdImpl::calibrate","Fmax set to:%d",100);
-		
-		action(HSTOP,9,1); 						// sets the stop @ camma on
-		ACS_DEBUG("::usdImpl::calibrate","hard stop to 1");
+		_SET_PROP(Fmax, 100, "usdImpl::calibrate()")
+		ACS_DEBUG_PARAM("::usdImpl::calibrate", "Fmax set to:%d", 100);
 
-		action(GO,-1,1);		// down                                     
-		ACS_DEBUG("::usdImpl::calibrate","down to find camma");
-		
-		ifp=1;
-		CIRATools::Wait(3,0);
-		_GET_PROP(status,m_status,"usdImpl::calibrate()")
-		if(m_status&MRUN) {
-			ACS_DEBUG("::usdImpl::calibrate","camma begin not found!");
-			_THROW_EX(USDStillRunning,"::usdImpl::calibrate()",ifp);
-			action(STOP);
-		}
-		
-		_GET_PROP(actPos,cammaBegin,"usdImpl::calibrate()")
-		ACS_DEBUG_PARAM("::usdImpl::calibrate","Camma begin at:%ld",cammaBegin);
-		//printf("cammaBegin = %ld\n", cammaBegin);
+		action(HSTOP, 9, 1); // sets the stop @ camma on
+		ACS_DEBUG("::usdImpl::calibrate", "hard stop to 1");
 
-		action(HSTOP,0,1); // disable HW stop 
-		ACS_DEBUG("::usdImpl::calibrate","hstop disabled!");
-		move (-10); // moves 10 steps further to avoid istheresis zone
-		CIRATools::Wait(1,0);
-		
-		action(HSTOP,1,1);  					 // sets the stop @ camma off
-		ACS_DEBUG("::usdImpl::calibrate","hard stop to 0");
-		
-		action(GO,-1,1);		// down                                       
-		ACS_DEBUG("::usdImpl::calibrate","down to find end of camma");
-		
-		ifp=2;
-		CIRATools::Wait(3,0);
-		_GET_PROP(status,m_status,"usdImpl::calibrate()")
-		if(m_status&MRUN) {
-			ACS_DEBUG("::usdImpl::calibrate","camma end not found!");
-			printf("inside if\n");
-			_THROW_EX(USDStillRunning,"::usdImpl::calibrate()",ifp);
-			printf("inside if\n");
+		action(GO, -1, 1); // down
+		ACS_DEBUG("::usdImpl::calibrate", "down to find camma");
+
+		ifp = 1;
+		CIRATools::Wait(3, 0);
+		_GET_PROP(status, m_status, "usdImpl::calibrate()")
+		if(m_status&MRUN)
+		{
+			ACS_DEBUG("::usdImpl::calibrate", "camma begin not found!");
+			_THROW_EX(USDStillRunning, "::usdImpl::calibrate()", ifp);
 			action(STOP);
 		}
 
-		_GET_PROP(actPos,cammaEnd,"usdImpl::calibrate()")
-		ACS_DEBUG_PARAM("::usdImpl::calibrate","Camma end at:%ld",cammaEnd);
-		//printf("cammaEnd = %ld\n", cammaEnd);
+		_GET_PROP(actPos, cammaBegin, "usdImpl::calibrate()")
+		ACS_DEBUG_PARAM("::usdImpl::calibrate", "Camma begin at: %ld", cammaBegin);
+
+		action(HSTOP, 0, 1); // disable HW stop
+		ACS_DEBUG("::usdImpl::calibrate", "hstop disabled!");
+		move(-10); // moves 10 steps further to avoid istheresis zone
+		CIRATools::Wait(1, 0);
+
+		action(HSTOP, 1, 1); // sets the stop @ camma off
+		ACS_DEBUG("::usdImpl::calibrate", "hard stop to 0");
+
+		action(GO, -1, 1); // down
+		ACS_DEBUG("::usdImpl::calibrate", "down to find end of camma");
+
+		ifp = 2;
+		CIRATools::Wait(3, 0);
+		_GET_PROP(status, m_status, "usdImpl::calibrate()")
+		if(m_status&MRUN)
+		{
+			ACS_DEBUG("::usdImpl::calibrate", "camma end not found!");
+			_THROW_EX(USDStillRunning,"::usdImpl::calibrate()", ifp);
+			action(STOP);
+		}
+
+		_GET_PROP(actPos, cammaEnd, "usdImpl::calibrate()")
+		ACS_DEBUG_PARAM("::usdImpl::calibrate", "Camma end at: %ld", cammaEnd);
  
-		//m_cammaEnd = cammaEnd;
-		m_cammaLen=cammaBegin-cammaEnd;
-		m_cammaPos=cammaEnd+m_cammaLen/2;
-		//m_cammaPos=10+m_step_giro-cammaEnd-m_cammaLen/2;
+		m_cammaLen = cammaBegin - cammaEnd;
+		m_cammaPos = cammaEnd + m_cammaLen / 2;
 
-		m_cammaLenD = (double)(m_cammaLen*m_step2deg);
-		//m_cammaPosD = (double)((10+m_step_giro-cammaEnd-m_cammaLen/2)*m_step2deg);
-		m_cammaPosD = (double)((m_step_giro-cammaEnd-m_cammaLen/2)*m_step2deg);
-		//printf("cammaLen = %f\n", cammaLenD);
-		//printf("cammaPos = %f\n", cammaPosD);
- 		ACS_DEBUG_PARAM("::usdImpl::calibrate","cammaLen:%d(step)",m_cammaLen);
- 		ACS_DEBUG_PARAM("::usdImpl::calibrate","cammaPos:%d(step)",m_cammaPos);
+		m_cammaLenD = (double)(m_cammaLen * m_step2deg);
+		m_cammaPosD = (double)((m_step_giro - cammaEnd - m_cammaLen / 2) * m_step2deg);
+		ACS_DEBUG_PARAM("::usdImpl::calibrate", "cammaLen: %d(step)", m_cammaLen);
+		ACS_DEBUG_PARAM("::usdImpl::calibrate", "cammaPos: %d(step)", m_cammaPos);
 
-		action(HSTOP,0,1); // disable HW stop 
-		ACS_DEBUG("::usdImpl::calibrate","hstop disabled!");
+		action(HSTOP, 0, 1); // disable HW stop
+		ACS_DEBUG("::usdImpl::calibrate", "hstop disabled!");
 
-		//CIRATools::Wait(0,250000);
-		_SET_PROP(Fmax,500,"usdImpl::calibrate()")
-		//CIRATools::Wait(0,250000);
-		_SET_PROP(cmdPos,m_cammaPos,"usdImpl::calibrate()")
+		_SET_PROP(Fmax, 500, "usdImpl::calibrate()")
+		_SET_PROP(cmdPos, m_cammaPos, "usdImpl::calibrate()")
 
-		CIRATools::Wait(1,0); // 1 sec
-		action(LCNTR,m_top<<USxS,4); // load the top_scale value on counter
+		CIRATools::Wait(1, 0); // 1 sec
+		action(LCNTR, m_top<<USxS, 4); // load the top_scale value on counter
 	}
 
-	_CATCH_EXCP_THROW_EX(CORBA::SystemException,corbaError,"::usdImpl::calibrate()",ifp)
-	_CATCH_EXCP_THROW_EX(ASErrors::DevIOErrorEx,DevIOError,"::usdImpl::calibrate()",ifp)		// for _GET_PROP
-	_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"::usdImpl::calibrate()",ifp)	// for local USD excp
+	_CATCH_EXCP_THROW_EX(CORBA::SystemException, corbaError, "::usdImpl::calibrate()", ifp)
+	_CATCH_EXCP_THROW_EX(ASErrors::DevIOErrorEx, DevIOError, "::usdImpl::calibrate()", ifp) // for _GET_PROP
+	_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "::usdImpl::calibrate()", ifp)	// for local USD excp
 
-	m_calibrate=true;
-	//CIRATools::Wait(0,250000);
-	//ThreadSyncGuard guard1(&m_mutex);
-	//_SET_CDB_D(cammaLen,cammaLenD,"::usdImpl::calibrate()");
-	//CIRATools::Wait(0,250000);
-	//ThreadSyncGuard guard2(&m_mutex);
-	//_SET_CDB_D(cammaPos,cammaPosD,"::usdImpl::calibrate()");
-	//CIRATools::Wait(0,250000);
-	//ThreadSyncGuard guard3(&m_mutex);
-	//_SET_CDB(calibrate,m_calibrate,"::usdImpl::calibrate()");
-	//CIRATools::Wait(0,250000);
-	//printf("baci::ThreadSyncGuard guard(&m_mutex);\n");
-	
-/*	ASErrors::USDCalibratedCompletion* cIp=new  ASErrors::USDCalibratedCompletion(__FILE__,__LINE__,"::usdImpl::calibrate()");
-	cIp->setCammaLen(m_cammaLen*m_step2deg);
-	cIp->setCammaPos(m_cammaPos*m_step2deg);	
-	return cIp->returnCompletion();
-*/
+	m_calibrate = true;
 }
 
-//ACSErr::Completion* USDImpl::calVer() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
 void USDImpl::calVer() throw (CORBA::SystemException,ASErrors::ASErrorsEx)
 {
 	ACS_TRACE("::USDImpl::calVer()");
 
-	//fstream ASCalibration("/archive/SRT-AS-Calibration.txt");
-	//ASCalibration.open ("/archive/SRT-AS-Calibration.txt", ios_base::out | ios_base::app);
+	int ifp = 0;
+	_VAR_CHK_EX(m_available, USDUnavailable, "::usdImpl::calver()");
+	_VAR_CHK_EX(m_calibrate, USDunCalibrated, "::usdImpl::calver()");
 
-	//double cammaLenD = (double)(m_cammaLen*m_step2deg);
-	//double cammaPosD = (double)((m_step_giro-m_cammaEnd-m_cammaLen/2)*m_step2deg);
-	//printf("cammaLen = %f in calVer\n", cammaLenD);
-	//printf("cammaPos = %f in calVer\n", cammaPosD);
-	//ASCalibration << cammaLenD << " " << cammaPosD;
+	try
+	{
+		action(CPOS, m_top<<USxS, 4); // top
+		_GET_PROP(status, m_status, "usdImpl::calibrate()")
 
-	int ifp=0;
-	_VAR_CHK_EX(m_available,USDUnavailable,"::usdImpl::calver()");
-	_VAR_CHK_EX(m_calibrate,USDunCalibrated,"::usdImpl::calver()");
-    	
-	try {
-		action(CPOS,m_top<<USxS,4);			// top
-		_GET_PROP(status,m_status,"usdImpl::calibrate()")
-		 
-		ifp=10;
-		if(stillRunning(m_top)) {	
+		ifp = 10;
+		if(stillRunning(m_top))
+		{
 			action(STOP);
-			_THROW_EX(USDStillRunning,"::usdImpl::calver()",ifp);
+			_THROW_EX(USDStillRunning, "::usdImpl::calver()", ifp);
 		}
-		if (!chkCal()) {
+		if(!chkCal())
+		{
 			m_calibrate = false;
-			//_SET_CDB(calibrate,m_calibrate,"::usdImpl::calibrate()");
-			//printf("ifp = %d\n", ifp);
-			//ASCalibration << m_calibrate << std::endl;
-                	_THROW_EX(USDunCalibrated,"::usdImpl::calver()",ifp);
+			_THROW_EX(USDunCalibrated, "::usdImpl::calver()", ifp);
 		}
-		//if (!chkCal())
-                //	_THROW_EX(USDunCalibrated,"::usdImpl::calver()",ifp);
-				
-		ifp=11;
-		int incr=m_cammaLen/2+5;
-		action(RPOS,incr<<USxS,4);			// move half camma len plus an istheresis to get sensor off
-		CIRATools::Wait(0,500000);	// 0.5 secs
 
-		if (!chkCal()) {
+		ifp = 11;
+		int incr = m_cammaLen / 2 + 5;
+		action(RPOS, incr<<USxS, 4); // move half camma len plus an istheresis to get sensor off
+		CIRATools::Wait(0, 500000); // 0.5 secs
+
+		if(!chkCal())
+		{
 			m_calibrate = false;
-			//_SET_CDB(calibrate,m_calibrate,"::usdImpl::calibrate()");
-			//printf("ifp = %d\n", ifp);
-			//ASCalibration << m_calibrate << std::endl;
-                	_THROW_EX(USDunCalibrated,"::usdImpl::calver()",ifp);
+			_THROW_EX(USDunCalibrated, "::usdImpl::calver()", ifp);
 		}
-		//if (!chkCal())
-		//	_THROW_EX(USDunCalibrated,"::usdImpl::calver()",ifp);
-			
-		action(CPOS, m_bottom<<USxS,4);		// to bottom
-		ifp=20;
-		_GET_PROP(status,m_status,"usdImpl::calibrate()")
-			
-		if(stillRunning(m_bottom)) {	
+
+		action(CPOS, m_bottom<<USxS, 4); // to bottom
+		ifp = 20;
+		_GET_PROP(status, m_status, "usdImpl::calibrate()")
+
+		if(stillRunning(m_bottom))
+		{
 			action(STOP);
-			//ASCalibration << m_calibrate << std::endl;
-			_THROW_EX(USDStillRunning,"::usdImpl::calver()",ifp);
+			_THROW_EX(USDStillRunning, "::usdImpl::calver()", ifp);
 		}
-			
-		if (!chkCal()) {
+
+		if(!chkCal())
+		{
 			m_calibrate = false;
-			//_SET_CDB(calibrate,m_calibrate,"::usdImpl::calibrate()");
-			//printf("ifp = %d\n", ifp);
-			//ASCalibration << m_calibrate << std::endl;
-                	_THROW_EX(USDunCalibrated,"::usdImpl::calver()",ifp);
+			_THROW_EX(USDunCalibrated, "::usdImpl::calver()", ifp);
 		}
-		//if (!chkCal())
-		//	_THROW_EX(USDunCalibrated,"::usdImpl::calver()",ifp);
-		
-		action(CPOS,0,4);	//to zero
-		ifp=30;
-		_GET_PROP(status,m_status,"usdImpl::calibrate()")
-			
-		if(stillRunning(0)) 	{	
+
+		action(CPOS, 0, 4); //to zero
+		ifp = 30;
+		_GET_PROP(status, m_status, "usdImpl::calibrate()")
+
+		if(stillRunning(0))
+		{
 			action(STOP);
-			//ASCalibration << m_calibrate << std::endl;
-			_THROW_EX(USDStillRunning,"::usdImpl::calver()",ifp);
+			_THROW_EX(USDStillRunning, "::usdImpl::calver()", ifp);
 		}
-			
-		if (!chkCal()) {
+
+		if(!chkCal())
+		{
 			m_calibrate = false;
-			//_SET_CDB(calibrate,m_calibrate,"::usdImpl::calibrate()");
-			//printf("ifp = %d\n", ifp);
-			//ASCalibration << m_calibrate << std::endl;
-                	_THROW_EX(USDunCalibrated,"::usdImpl::calver()",ifp);
+			_THROW_EX(USDunCalibrated,"::usdImpl::calver()",ifp);
 		}
-		//if (!chkCal())
-		//	_THROW_EX(USDunCalibrated,"::usdImpl::calver()",ifp);
-	
 	}
 
-	_CATCH_EXCP_THROW_EX(CORBA::SystemException,corbaError,"::usdImpl::calver()",ifp)	// for CORBA
-	_CATCH_EXCP_THROW_EX(ASErrors::DevIOErrorEx,DevIOError,"::usdImpl::calver()",ifp)	// for _GET_PROP
-	_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"::usdImpl::calver()",ifp)	// for local USD excp
-	
-	//CompletionImpl* cp=new  ASErrors::NoErrorCompletion();
-	//return cp->returnCompletion();
+	_CATCH_EXCP_THROW_EX(CORBA::SystemException, corbaError, "::usdImpl::calver()", ifp) // for CORBA
+	_CATCH_EXCP_THROW_EX(ASErrors::DevIOErrorEx, DevIOError, "::usdImpl::calver()", ifp) // for _GET_PROP
+	_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "::usdImpl::calver()", ifp) // for local USD excp
 }
 
-void USDImpl:: writeCalibration(CORBA::Double_out cammaLenD, CORBA::Double_out cammaPosD, CORBA::Boolean_out calibrate) throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+void USDImpl::writeCalibration(CORBA::Double_out cammaLenD, CORBA::Double_out cammaPosD, CORBA::Boolean_out calibrate) throw (CORBA::SystemException,ASErrors::ASErrorsEx)
 {
-	_SET_CDB_D(cammaLen,m_cammaLenD,"::usdImpl::calibrate()");
-	_SET_CDB_D(cammaPos,m_cammaPosD,"::usdImpl::calibrate()");
-	_SET_CDB(calibrate,m_calibrate,"::usdImpl::calibrate()");
-	
+	_SET_CDB_D(cammaLen, m_cammaLenD, "::usdImpl::calibrate()");
+	_SET_CDB_D(cammaPos, m_cammaPosD, "::usdImpl::calibrate()");
+	_SET_CDB(calibrate, m_calibrate, "::usdImpl::calibrate()");
+
 	cammaLenD = m_cammaLenD;
 	cammaPosD = m_cammaPosD;
 	calibrate = m_calibrate;
 }
 
-void USDImpl::posTable (const ACS::doubleSeq& theActuatorsCorrections, CORBA::Long theParPositions, CORBA::Double theDeltaEL, CORBA::Long theThreshold)
+void USDImpl::posTable(const ACS::doubleSeq& theActuatorsCorrections, CORBA::Long theParPositions, CORBA::Double theDeltaEL, CORBA::Long theThreshold)
 {
 	parPositions = theParPositions;
 	deltaEL = theDeltaEL;
 	threshold = theThreshold;
 
 	if(actuatorsCorrections != NULL)
+	{
 		delete [] actuatorsCorrections;
+	}
 	if(elevations != NULL)
+	{
 		delete [] elevations;
-	actuatorsCorrections = new double [parPositions];
-	elevations = new double [parPositions-1];
-	for (int s = 0; s < parPositions; s++) {
-		actuatorsCorrections [s] = theActuatorsCorrections[s];
-		if (s < parPositions-1)
-			elevations[s] = (s+1)*deltaEL;
+	}
+	actuatorsCorrections = new double[parPositions];
+	elevations = new double[parPositions-1];
+	for (int s = 0; s < parPositions; s++)
+	{
+		actuatorsCorrections[s] = theActuatorsCorrections[s];
+		if(s < parPositions - 1)
+		{
+			elevations[s] = (s + 1) * deltaEL;
+		}
 	}
 }
 
-void USDImpl::update (CORBA::Double elevation) throw (CORBA::SystemException,ASErrors::ASErrorsEx)
+void USDImpl::update(CORBA::Double elevation) throw (CORBA::SystemException, ASErrors::ASErrorsEx)
 {
 	double updatePosMM = 0.0;
 	long updatePos;
 
-	try {
-		if (m_profile == 1) // SHAPED FIXED
-			updatePosMM = actuatorsCorrections[parPositions-5]; // 45
-		if (m_profile == 3) // PARABOLIC FIXED
-			updatePosMM = actuatorsCorrections[parPositions-5] + actuatorsCorrections[parPositions-1]; // 45 + P
+	try
+	{
+		if(m_profile == 1) // SHAPED FIXED
+		{
+			updatePosMM = actuatorsCorrections[parPositions - 5]; // 45
+		}
+		if(m_profile == 3) // PARABOLIC FIXED
+		{
+			updatePosMM = actuatorsCorrections[parPositions - 5] + actuatorsCorrections[parPositions - 1]; // 45 + P
+		}
 		else // SHAPED
 		{
-			if (elevation <= 15.0)
+			if(elevation <= 15.0)
+			{
 				updatePosMM = actuatorsCorrections[0];
-			else if (elevation >= 90 )
+			}
+			else if(elevation >= 90)
+			{
 				updatePosMM = actuatorsCorrections[parPositions-2];
+			}
 			else
 			{
-				int k = (int)(floor(elevation/deltaEL));
-				updatePosMM = ((elevation-elevations[k-1])/deltaEL)*(actuatorsCorrections[k]-actuatorsCorrections[k-1])+actuatorsCorrections[k-1];
+				int k = (int)(floor(elevation / deltaEL));
+				updatePosMM = ((elevation - elevations[k - 1]) / deltaEL) * (actuatorsCorrections[k] - actuatorsCorrections[k - 1]) + actuatorsCorrections[k - 1];
 			}
-			if (m_profile == 2) // SHAPED + PARABOLIC
-				updatePosMM += actuatorsCorrections[parPositions-1];
+			if(m_profile == 2) // SHAPED + PARABOLIC
+			{
+				updatePosMM += actuatorsCorrections[parPositions - 1];
+			}
 		}
-		updatePos = (CORBA::Long)(updatePosMM*MM2STEP);
-		if (updatePos > 21000)
-			updatePos = 21000;
-		if (updatePos < -21000)
-			updatePos = -21000;
-		if (updatePos == m_lastCmdStep)
+		updatePos = (CORBA::Long)(updatePosMM * MM2STEP);
+		updatePos = std::max(updatePos, m_bottom);
+		updatePos = std::min(updatePos, m_top);
+		if(updatePos == m_lastCmdStep)
 			return;
-		_GET_PROP(status,m_status,"usdImpl::calibrate()")
+		_GET_PROP(status, m_status, "usdImpl::calibrate()")
 		bool running = m_status&MRUN;
-		if (running)
+		if(running)
 			return;
-		_SET_PROP(cmdPos,updatePos,"usdImpl::update()")
+		_SET_PROP(cmdPos, updatePos, "usdImpl::update()")
 		m_lastCmdStep = updatePos;
 	}
-	_CATCH_EXCP_THROW_EX(CORBA::SystemException,corbaError,"::usdImpl::update()",m_addr)	// for CORBA
-	_CATCH_EXCP_THROW_EX(ASErrors::DevIOErrorEx,DevIOError,"::usdImpl::update()",m_addr)	// for _GET_PROP
-	_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl,USDError,"::usdImpl::update()",m_addr)	// for local USD excp
+	_CATCH_EXCP_THROW_EX(CORBA::SystemException, corbaError, "::usdImpl::update()", m_addr)	// for CORBA
+	_CATCH_EXCP_THROW_EX(ASErrors::DevIOErrorEx, DevIOError, "::usdImpl::update()", m_addr)	// for _GET_PROP
+	_CATCH_ACS_EXCP_THROW_EX(ASErrors::ASErrorsExImpl, USDError, "::usdImpl::update()", m_addr)	// for local USD excp
 }
 
 void USDImpl::exImplCheck(ASErrors::ASErrorsExImpl ex)
@@ -625,91 +591,94 @@ void USDImpl::exImplCheck(ASErrors::ASErrorsExImpl ex)
 
 	int err;
 
-	switch (err=ex.getErrorCode()) {
+	switch (err = ex.getErrorCode())
+	{
 		// warnings	
 		case ASErrors::SocketReconn:
-            {
-            //    _THROW_EX(SocketReconn,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_WARNING,"Warning exception %d",err));
-                break;
-            }
+		{
+			//	_THROW_EX(SocketReconn,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_WARNING, "Warning exception %d", err));
+			break;
+		}
 		case ASErrors::Incomplete:
-            {
-             //   _THROW_EX(Incomplete,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_WARNING,"Warning exception %d",err));
-                break;
-            }
+		{
+			//   _THROW_EX(Incomplete,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_WARNING, "Warning exception %d", err));
+			break;
+		}
 		case ASErrors::USDUnavailable: 
-            {
-             //   _THROW_EX(USDUnavailable,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_WARNING,"Warning exception %d",err));
-                break;
-            }
+		{
+			//   _THROW_EX(USDUnavailable,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_WARNING, "Warning exception %d", err));
+			break;
+		}
 		case ASErrors::Nak: 
-            {
-             //   _THROW_EX(Nak,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_WARNING,"Warning exception %d",err));
-                break;
-            }
+		{
+			//   _THROW_EX(Nak,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_WARNING, "Warning exception %d", err));
+			break;
+		}
 		case ASErrors::USDunCalibrated:
-		    {
-             //   _THROW_EX(USDunCalibrated,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_WARNING,"Warning exception %d",err));
-			    break;
-            }
+		{
+			//   _THROW_EX(USDunCalibrated,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_WARNING, "Warning exception %d", err));
+			break;
+		}
 
 		//critical errors compromising the USD working	
 		case ASErrors::LibrarySocketError: 
-            {
-             //   _THROW_EX(LibrarySocketError,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_CRITICAL,"Critical exception %d",err));
-                m_failures++;
-                break;
-            }
+		{
+			//   _THROW_EX(LibrarySocketError,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_CRITICAL, "Critical exception %d", err));
+			m_failures++;
+			break;
+		}
 		case ASErrors::USDConnectionError: 
-            {
-             //   _THROW_EX(USDConnectionError,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_CRITICAL,"Critical exception %d",err));
-                m_failures++;
-                break;
-            }
+		{
+			//   _THROW_EX(USDConnectionError,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_CRITICAL, "Critical exception %d", err));
+			m_failures++;
+			break;
+		}
 		case ASErrors::USDTimeout: 
-            {
-             //   _THROW_EX(USDTimeout,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_CRITICAL,"Critical exception %d",err));
-                m_failures++;
-                break;
-            }
+		{
+			 //   _THROW_EX(USDTimeout,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_CRITICAL, "Critical exception %d", err));
+			m_failures++;
+			break;
+		}
 		case ASErrors::SocketTOut:
-            {
-             //   _THROW_EX(SocketTOut,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_CRITICAL,"Critical exception %d",err));
-                m_failures++;
-                break;
-            }
+		{
+			//   _THROW_EX(SocketTOut,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_CRITICAL, "Critical exception %d", err));
+			m_failures++;
+			break;
+		}
 		case ASErrors::SocketFail: 
-		    {
-             //   _THROW_EX(SocketFail,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_CRITICAL,"Critical exception %d",err));
-                m_failures++;
-			    break;
-            }
+		{
+			//   _THROW_EX(SocketFail,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_CRITICAL, "Critical exception %d", err));
+			m_failures++;
+			break;
+		}
 
 		//  errors		
 		default:
-            {
-             //   _THROW_EX(USDError,"::usdImpl::exImplCheck()",err);
-			    ACS_SHORT_LOG((LM_ERROR,"Error exception %d",err));
-			    break;
-            }
+		{
+			//   _THROW_EX(USDError,"::usdImpl::exImplCheck()",err);
+			ACS_SHORT_LOG((LM_ERROR, "Error exception %d", err));
+			break;
+		}
 	}
-	if (m_failures == MAX_FAILURES)
-		m_available=false;
-    
+	if(m_failures == MAX_FAILURES)
+	{
+		m_available = false;
+	}
+
 	ex.log();
 }
 
-void USDImpl::exCheck(ASErrors::ASErrorsEx ex) 
+void USDImpl::exCheck(ASErrors::ASErrorsEx ex)
 {
 	ACS_TRACE("USDImpl::exCheck()");
 
@@ -717,63 +686,71 @@ void USDImpl::exCheck(ASErrors::ASErrorsEx ex)
 	exImplCheck(exImpl);
 }
  
-bool USDImpl::compCheck(ACSErr::CompletionImpl& comp) 
+bool USDImpl::compCheck(ACSErr::CompletionImpl& comp)
 {
 	ACS_TRACE("USDImpl::compCheck()");
 
-	if(comp.isErrorFree())	{
+	if(comp.isErrorFree())
+	{
 		m_failures = 0;
 		return false;
-	} else {
-		// convert a completion in C++ excpt
-		ASErrors::USDErrorExImpl ex(comp.getErrorTraceHelper()->getErrorTrace()); // senza accodamento
-		//ASErrors::USDErrorExImpl ex(&comp,__FILE__,__LINE__,"::usdImpl::calibrate()"); con accodamento
-		exImplCheck(ex);
-   	return true;
 	}
-} 
+	else
+	{
+		ASErrors::USDErrorExImpl ex(comp.getErrorTraceHelper()->getErrorTrace()); // senza accodamento
+		exImplCheck(ex);
+		return true;
+	}
+}
 
-void USDImpl::action( int act,int par,int nb) throw (ASErrors::ASErrorsExImpl)
+void USDImpl::action(int act, int par, int nb) throw (ASErrors::ASErrorsExImpl)
 {
 	ACS_TRACE("usdImpl::action()");
-	    
-       _VAR_CHK_EXIMPL(m_available,USDUnavailable,"usdImpl::action()");   //throw USD unuvailable excpt
 
-       try {
-	CompletionImpl comp(m_pLan->sendUSDCmd(act,m_addr,par,nb));
-        if (compCheck(comp))
-        	throw ASErrors::sendCmdErrExImpl(comp,__FILE__,__LINE__,"usdImpl::action()");
-        }
-	_CATCH_EXCP_THROW_EXIMPL(CORBA::SystemException,ASErrors::corbaErrorExImpl,"usdImpl::action()",act)
+	_VAR_CHK_EXIMPL(m_available, USDUnavailable, "usdImpl::action()"); //throw USD unuvailable excpt
+
+	try
+	{
+		CompletionImpl comp(m_pLan->sendUSDCmd(act, m_addr, par, nb));
+		if(compCheck(comp))
+		{
+			throw ASErrors::sendCmdErrExImpl(comp, __FILE__, __LINE__, "usdImpl::action()");
+		}
+	}
+	_CATCH_EXCP_THROW_EXIMPL(CORBA::SystemException,ASErrors::corbaErrorExImpl, "usdImpl::action()", act)
 }
 
 bool USDImpl::stillRunning(long pos) throw (ASErrors::ASErrorsExImpl)
 {
-		ACS_TRACE("usdImpl::stillRunning()");
+	ACS_TRACE("usdImpl::stillRunning()");
 
-	ACSErr::Completion_var cp_sp;
 	bool running;
-	int tout;
-	long fmax, startpos;
-	time_t endt;
 
- 	try {
-		_GET_PROP(Fmax,fmax,"usdImpl::stillRunning()")
-		_GET_PROP(actPos,startpos,"usdImpl::stillRunning()")
-		tout=labs(pos-startpos)/fmax+2;	// adds two secs for safety
-		
-		for(endt=time(NULL)+tout; time(NULL)<endt;CIRATools::Wait(0,500000)) // loop every 1/2 sec
+	try
+	{
+		long fmax, startpos;
+		_GET_PROP(Fmax, fmax, "usdImpl::stillRunning()")
+		_GET_PROP(actPos, startpos, "usdImpl::stillRunning()")
+		int tout = labs(pos - startpos) / fmax + 2; // adds two secs for safety
+
+		for(time_t endt = time(NULL) + tout; time(NULL) < endt; CIRATools::Wait(0, 500000)) // loop every 1/2 sec
 		{
-			_GET_PROP(status,m_status,"usdImpl::stillRunning()")
-			if(!(m_status&MRUN)) break;				// exit if stopped
+			_GET_PROP(status, m_status, "usdImpl::stillRunning()")
+			if(!(m_status&MRUN))
+			{
+				break; // exit if stopped
+			}
 		}
 	}
-	_CATCH_EXCP_THROW_EXIMPL(CORBA::SystemException,ASErrors::corbaErrorExImpl,"USDImpl::stillRunning()",m_status)
-	_CATCH_EXCP_THROW_EXIMPL(ASErrors::DevIOErrorEx,ASErrors::DevIOErrorExImpl,"USDImpl::stillRunning()",m_status)	// for _GET_PROP
+	_CATCH_EXCP_THROW_EXIMPL(CORBA::SystemException, ASErrors::corbaErrorExImpl, "USDImpl::stillRunning()", m_status)
+	_CATCH_EXCP_THROW_EXIMPL(ASErrors::DevIOErrorEx, ASErrors::DevIOErrorExImpl, "USDImpl::stillRunning()", m_status) // for _GET_PROP
 
-	running=m_status&MRUN;
-	ACS_DEBUG_PARAM("::usdImpl::stillRunning","running:%d",running);
-	if (running) ACS_SHORT_LOG((LM_WARNING,"stillRunning():USD %d still running!",m_addr));
+	running = m_status&MRUN;
+	ACS_DEBUG_PARAM("::usdImpl::stillRunning", "running: %d", running);
+	if(running)
+	{
+		ACS_SHORT_LOG((LM_WARNING, "stillRunning(): USD %d still running!", m_addr));
+	}
 	return running;
 }
 
@@ -783,124 +760,173 @@ bool USDImpl::chkCal() throw (ASErrors::ASErrorsExImpl)
 
 	int fgiro;
 
- 	try {
-		_GET_PROP(actPos,fgiro,"USDImpl::chkCal()")
-		_GET_PROP(status,m_status,"usdImpl::calibrate()")
-			fgiro%=m_step_giro;
-
+	try
+	{
+		_GET_PROP(actPos, fgiro, "USDImpl::chkCal()")
+		_GET_PROP(status, m_status, "usdImpl::calibrate()")
+		fgiro %= m_step_giro;
 	}
-	_CATCH_EXCP_THROW_EXIMPL(CORBA::SystemException,ASErrors::corbaErrorExImpl,"USDImpl::chkCal()",m_status)
-	_CATCH_EXCP_THROW_EXIMPL(ASErrors::DevIOErrorEx,ASErrors::DevIOErrorExImpl,"USDImpl::chkCal()",m_status)	// for _GET_PROP
+	_CATCH_EXCP_THROW_EXIMPL(CORBA::SystemException, ASErrors::corbaErrorExImpl, "USDImpl::chkCal()", m_status)
+	_CATCH_EXCP_THROW_EXIMPL(ASErrors::DevIOErrorEx, ASErrors::DevIOErrorExImpl, "USDImpl::chkCal()", m_status) // for _GET_PROP
 
-	if (fgiro > m_step_giro/2) fgiro=m_step_giro-fgiro;  //compute complement to full turn
-	ACS_DEBUG_PARAM("::usdImpl::isRunning","fgiro: %d ",fgiro);
-	ACS_DEBUG_PARAM("::usdImpl::isRunning"," camma: %d",m_status&CAMM);
-	//printf("m_status&CAMM in chkCal() = %d\n", m_status&CAMM);
-	if(fgiro < m_cammaLen/2 && m_status&CAMM) return true;
-	else if (fgiro > m_cammaLen/2 && !(m_status&CAMM)) return true;
-	else return false;
+	if(fgiro > m_step_giro/2)
+	{
+		fgiro = m_step_giro - fgiro; //compute complement to full turn
+	}
+	ACS_DEBUG_PARAM("::usdImpl::isRunning", "fgiro: %d ", fgiro);
+	ACS_DEBUG_PARAM("::usdImpl::isRunning", "camma: %d ", m_status&CAMM);
+
+	if(fgiro < m_cammaLen / 2 && m_status&CAMM)
+	{
+		return true;
+	}
+	else if(fgiro > m_cammaLen / 2 && !(m_status&CAMM))
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
 }
 
 /* ----------------------------------------------------------------*/
 USDImpl::~USDImpl()
 {
-    // ACS_TRACE is used for debugging purposes
-    ACS_TRACE("::USDImpl::~USDImpl");
-    ACS_DEBUG_PARAM("::USDImpl::~USDImpl", "Destroying %s...", name());
-    
+	ACS_TRACE("::USDImpl::~USDImpl");
+	ACS_DEBUG_PARAM("::USDImpl::~USDImpl", "Destroying %s...", name());
 }
 
-       
+
 /* --------------------- [ CORBA interface ] ----------------------*/
 
 ACS::RWlong_ptr USDImpl::delay() throw (CORBA::SystemException)
 {
-	if(m_delay_sp==0) return ACS::RWlong::_nil();
-	ACS::RWlong_var prop=ACS::RWlong::_narrow(m_delay_sp->getCORBAReference());
+	if(m_delay_sp == 0)
+	{
+		return ACS::RWlong::_nil();
+	}
+	ACS::RWlong_var prop = ACS::RWlong::_narrow(m_delay_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::RWlong_ptr USDImpl::cmdPos() throw (CORBA::SystemException)
 {
-	if(m_cmdPos_sp==0) return ACS::RWlong::_nil();
-	ACS::RWlong_var prop=ACS::RWlong::_narrow(m_cmdPos_sp->getCORBAReference());
+	if(m_cmdPos_sp == 0)
+	{
+		return ACS::RWlong::_nil();
+	}
+	ACS::RWlong_var prop = ACS::RWlong::_narrow(m_cmdPos_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::RWlong_ptr USDImpl::Fmin() throw (CORBA::SystemException)
 {
-	if(m_Fmin_sp==0) return ACS::RWlong::_nil();
-	ACS::RWlong_var prop=ACS::RWlong::_narrow(m_Fmin_sp->getCORBAReference());
+	if(m_Fmin_sp == 0)
+	{
+		return ACS::RWlong::_nil();
+	}
+	ACS::RWlong_var prop = ACS::RWlong::_narrow(m_Fmin_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::RWlong_ptr USDImpl::Fmax() throw (CORBA::SystemException)
 {
-	if(m_Fmax_sp==0) return ACS::RWlong::_nil();
-	ACS::RWlong_var prop=ACS::RWlong::_narrow(m_Fmax_sp->getCORBAReference());
+	if(m_Fmax_sp == 0)
+	{
+		return ACS::RWlong::_nil();
+	}
+	ACS::RWlong_var prop = ACS::RWlong::_narrow(m_Fmax_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::RWlong_ptr USDImpl::acc() throw (CORBA::SystemException)
 {
-	if(m_acc_sp==0) return ACS::RWlong::_nil();
-	ACS::RWlong_var prop=ACS::RWlong::_narrow(m_acc_sp->getCORBAReference());
+	if(m_acc_sp == 0)
+	{
+		return ACS::RWlong::_nil();
+	}
+	ACS::RWlong_var prop = ACS::RWlong::_narrow(m_acc_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::RWlong_ptr USDImpl::uBits() throw (CORBA::SystemException)
 {
-	if(m_uBits_sp==0) return ACS::RWlong::_nil();
-	ACS::RWlong_var prop=ACS::RWlong::_narrow(m_uBits_sp->getCORBAReference());
+	if(m_uBits_sp == 0)
+	{
+		return ACS::RWlong::_nil();
+	}
+	ACS::RWlong_var prop = ACS::RWlong::_narrow(m_uBits_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::RWdouble_ptr USDImpl::lmCorr() throw (CORBA::SystemException)
 {
-	if(m_lmCorr_sp==0) return ACS::RWdouble::_nil();
-	ACS::RWdouble_var prop=ACS::RWdouble::_narrow(m_lmCorr_sp->getCORBAReference());
+	if(m_lmCorr_sp == 0)
+	{
+		return ACS::RWdouble::_nil();
+	}
+	ACS::RWdouble_var prop = ACS::RWdouble::_narrow(m_lmCorr_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::ROlong_ptr USDImpl::actPos() throw (CORBA::SystemException)
 {
-	if(m_actPos_sp==0) return ACS::ROlong::_nil();
-	ACS::ROlong_var prop=ACS::ROlong::_narrow(m_actPos_sp->getCORBAReference());
+	if(m_actPos_sp == 0)
+	{
+		return ACS::ROlong::_nil();
+	}
+	ACS::ROlong_var prop = ACS::ROlong::_narrow(m_actPos_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::ROpattern_ptr USDImpl::status() throw (CORBA::SystemException)
 {
-	if(m_status_sp==0) return ACS::ROpattern::_nil();
-	ACS::ROpattern_var prop=ACS::ROpattern::_narrow(m_status_sp->getCORBAReference());
+	if(m_status_sp == 0)
+	{
+		return ACS::ROpattern::_nil();
+	}
+	ACS::ROpattern_var prop = ACS::ROpattern::_narrow(m_status_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::ROlong_ptr USDImpl::softVer() throw (CORBA::SystemException)
 {
-	if(m_softVer_sp==0) return ACS::ROlong::_nil();
-	ACS::ROlong_var prop=ACS::ROlong::_narrow(m_softVer_sp->getCORBAReference());
+	if(m_softVer_sp == 0)
+	{
+		return ACS::ROlong::_nil();
+	}
+	ACS::ROlong_var prop = ACS::ROlong::_narrow(m_softVer_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::ROlong_ptr USDImpl::type() throw (CORBA::SystemException)
 {
-	if(m_type_sp==0) return ACS::ROlong::_nil();
-	ACS::ROlong_var prop=ACS::ROlong::_narrow(m_type_sp->getCORBAReference());
+	if(m_type_sp == 0)
+	{
+		return ACS::ROlong::_nil();
+	}
+	ACS::ROlong_var prop = ACS::ROlong::_narrow(m_type_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::RWdouble_ptr USDImpl::gravCorr() throw (CORBA::SystemException)
 {
-	if(m_gravCorr_sp==0) return ACS::RWdouble::_nil();
-	ACS::RWdouble_var prop=ACS::RWdouble::_narrow(m_gravCorr_sp->getCORBAReference());
+	if(m_gravCorr_sp == 0)
+	{
+		return ACS::RWdouble::_nil();
+	}
+	ACS::RWdouble_var prop = ACS::RWdouble::_narrow(m_gravCorr_sp->getCORBAReference());
 	return prop._retn();
 }
 
 ACS::RWdouble_ptr USDImpl::userOffset() throw (CORBA::SystemException)
 {
-	if(m_userOffset_sp==0) return ACS::RWdouble::_nil();
-	ACS::RWdouble_var prop=ACS::RWdouble::_narrow(m_userOffset_sp->getCORBAReference());
+	if(m_userOffset_sp == 0)
+	{
+		return ACS::RWdouble::_nil();
+	}
+	ACS::RWdouble_var prop = ACS::RWdouble::_narrow(m_userOffset_sp->getCORBAReference());
 	return prop._retn();
 }
 
@@ -908,8 +934,4 @@ ACS::RWdouble_ptr USDImpl::userOffset() throw (CORBA::SystemException)
 #include <maciACSComponentDefines.h>
 MACI_DLL_SUPPORT_FUNCTIONS(USDImpl)
 /* ----------------------------------------------------------------*/
-
-
 /*___oOo___*/
-
-


### PR DESCRIPTION
This method returns in a long variable passed by reference, the last known status of the actuator without any call to the actual hardware. This is a measure to prevent occupying the LAN socket in case of tracking. Since during the tracking process the status is updated every time the USD has to move to a different position, I think is safe to assume that the returned status has been read no more than a couple seconds before.

In the diff section you will see a lot of lines changed, that's because I fixed the indentation on multiple files in order for them to be readable in a much easier way. The only actual changes are located on the following lines:
- usd.idl, line 184 on the right side of the screen
- usdImpl.h, line 346. Also changed `m_top` and `m_bottom` from int to long to avoid some warnings about some comparison that happens in the `update` method
- usdImpl.cpp, line 304 on the right, getStatus method. The rest of the file has been cleaned out from some old debugging printfs and commented code that is not useful anymore.

If needed, we can change this behavior in order to force an update of the USD status if the last known status becomes too old.