### PR TITLE
Fix #487, moved the start time acquisition after the SecureArea lock

### DIFF
--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossWorkingThread.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossWorkingThread.cpp
@@ -24,11 +24,11 @@ void CSRTActiveSurfaceBossWorkingThread::onStop()
 
 void CSRTActiveSurfaceBossWorkingThread::runLoop()
 {
+	IRA::CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+
 	TIMEVALUE now;
 	IRA::CIRATools::getTime(now);
 	ACS::Time t0 = now.value().value;
-
-	IRA::CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
 	try
 	{
 		resource->workingActiveSurface();


### PR DESCRIPTION
When the SecureArea is not locked by any other thread, locking it requires virtually no time (a few microseconds). So now the locking elapsed time is not taken into account anymore. In this way the total execution time for a single iteration is equal to Tlock + Texecution, with Tlock usually negligible, or greater than a second whenever a new profile is chosen (due to a Wait(1000000) in the other locking thread).