### PR TITLE
Fix #486, replaced `SRTActiveSurfaceSectorThread::run()` with `::runLoop()`

### DIFF
--- a/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossCore.h
+++ b/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossCore.h
@@ -79,6 +79,7 @@ class CSRTActiveSurfaceBossCore {
     friend class SRTActiveSurfaceBossImpl;
     friend class CSRTActiveSurfaceBossWatchingThread;
     friend class CSRTActiveSurfaceBossWorkingThread;
+    friend class CSRTActiveSurfaceBossSectorThread;
 public:
     /**
      * Constructor. Default Constructor.
@@ -118,8 +119,6 @@ public:
     void onewayAction(ActiveSurface::TASOneWayAction onewayAction, int circle, int actuator, int radius, double elevation, double correction, long incr, ActiveSurface::TASProfile profile) throw (ComponentErrors::UnexpectedExImpl, ComponentErrors::CouldntCallOperationExImpl, ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentNotActiveExImpl);
 
     void workingActiveSurface() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx);
-
-    void sectorActiveSurface(int sector) throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx);
 
     void watchingActiveSurfaceStatus() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::CouldntGetAttributeExImpl, ComponentErrors::ComponentNotActiveExImpl);
 

--- a/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossSectorThread.h
+++ b/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossSectorThread.h
@@ -1,14 +1,15 @@
 #ifndef _SRTACTIVESURFACEBOSSSECTORTHREAD_H_
 #define _SRTACTIVESURFACEBOSSSECTORTHREAD_H_
 
-/* ********************************************************************************* */
+/*************************************************************************************/
 /* OAC Osservatorio Astronomico di Cagliari                                          */
 /* $Id: SRTActiveSurfaceBossSector1Thread.h,v 1.1 2010-07-26 12:36:49 c.migoni Exp $ */
 /*                                                                                   */
 /* This code is under GNU General Public Licence (GPL).                              */
 /*                                                                                   */
-/* Who                                          when        What                     */
-/* Giuseppe Carboni (giuseppe.carboni@inaf.it)  02/07/2019  Creation                 */
+/* Who                                            When        What                   */
+/* Giuseppe Carboni (giuseppe.carboni@inaf.it)    02/07/2019    Creation             */
+/*************************************************************************************/
 
 #include <acsThread.h>
 #include <IRA>
@@ -49,18 +50,14 @@ public:
       * This method overrides the thread implementation class.
       * The thread can be exited by calling ACS::ThreadBase::stop or ACS::ThreadBase::exit command.
      */
-     virtual void run();
-
-     /**
-      * This method is used to set the sector to be initialized. It MUST be called before starting the thread execution
-     */
-     virtual void setSector(int sector);
+     virtual void runLoop();
 
 private:
-
-    IRA::CSecureArea<CSRTActiveSurfaceBossCore> *m_core;
-    CSRTActiveSurfaceBossCore *boss;
+    CSRTActiveSurfaceBossCore *m_boss;
     int m_sector;
+    std::string m_thread_name;
+    std::ifstream m_usdTable;
+    ACS::Time timestart;
 };
 
 #endif /*_SRTACTIVESURFACEBOSSSECTORTHREAD_H_*/

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossCore.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossCore.cpp
@@ -1349,52 +1349,6 @@ void CSRTActiveSurfaceBossCore::watchingActiveSurfaceStatus() throw (ComponentEr
     //printf("NO error\n");
 }
 
-void CSRTActiveSurfaceBossCore::sectorActiveSurface(int sector) throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx)
-{
-	if (sector == -1) {
-		ACS_SHORT_LOG ((LM_INFO, "You have to set a sector first!"));
-		exit(-1);
-	}
-
-	printf("sector%d start\n", sector+1);
-	char serial_usd[23];
-	char graf[5], mecc[4];
-	std::stringstream value;
-	value << CDBPATH;
-	value << "alma/AS/tab_convUSD_S";
-	value << sector+1;
-	value << ".txt";
-
-	ifstream usdTable(value.str().c_str());
-	if (!usdTable) {
-		ACS_SHORT_LOG ((LM_INFO, "File %s not found", value.str().c_str()));
-		exit(-1);
-	}
-
-	// Get reference to usd components
-	while (usdTable >> lanIndexes[sector] >> circleIndexes[sector] >> usdCircleIndexes[sector] >> serial_usd >> graf >> mecc)
-	{
-		usd[circleIndexes[sector]][usdCircleIndexes[sector]] = ActiveSurface::USD::_nil();
-
-		try
-		{
-			printf("S%d: circleIndexS%d = %d, usdCircleIndexS%d = %d\n", sector+1, sector+1, circleIndexes[sector], sector+1, usdCircleIndexes[sector]);
-			usd[circleIndexes[sector]][usdCircleIndexes[sector]] = m_services->getComponent<ActiveSurface::USD>(serial_usd);
-			lanradius[circleIndexes[sector]][lanIndexes[sector]] = usd[circleIndexes[sector]][usdCircleIndexes[sector]];
-			usdCounters[sector]++;
-		}
-		catch (maciErrType::CannotGetComponentExImpl& ex)
-		{
-			_ADD_BACKTRACE(ComponentErrors::CouldntGetComponentExImpl,Impl,ex,"CSRTActiveSurfaceBossCore::sectorActiveSurface()");
-			Impl.setComponentName(serial_usd);
-			Impl.log(LM_DEBUG);
-		}
-	}
-
-	printf("sector%d done\n", sector+1);
-	m_sector[sector] = true;
-}
-
 void CSRTActiveSurfaceBossCore::workingActiveSurface() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx)
 {
 	if (AutoUpdate) {

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossImpl.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossImpl.cpp
@@ -14,601 +14,588 @@ using namespace SimpleParser;
 
 class SRTActiveSurfaceProfile2String {
 public:
-	static char *valToStr(const ActiveSurface::TASProfile& val) {
-		char *c=new char[16];
-		if (val==ActiveSurface::AS_SHAPED) {
-			strcpy(c,"S");
-		}
-		if (val==ActiveSurface::AS_SHAPED_FIXED) {
-			strcpy(c,"SF");
-		}
-		if (val==ActiveSurface::AS_PARABOLIC) {
-			strcpy(c,"P");
-		}
-		if (val==ActiveSurface::AS_PARABOLIC_FIXED) {
-			strcpy(c,"PF");
-		}
-		return c;
-	}
-	static ActiveSurface::TASProfile strToVal(const char* str) throw (ParserErrors::BadTypeFormatExImpl) {
-		IRA::CString strVal(str);
-		strVal.MakeUpper();
-		if (strVal=="S") {
-			return ActiveSurface::AS_SHAPED;
-		}
-		else if (strVal=="SF") {
-			return ActiveSurface::AS_SHAPED_FIXED;
-		}
-		else if (strVal=="P") {
-			return ActiveSurface::AS_PARABOLIC;
-		}
-		else if (strVal=="PF") {
-			return ActiveSurface::AS_PARABOLIC_FIXED;
-		}
-		else {
-			_EXCPT(ParserErrors::BadTypeFormatExImpl,ex,"SRTActiveSurfaceProfile2String::strToVal()");
-			throw ex;
-		}
-	}
+    static char *valToStr(const ActiveSurface::TASProfile& val) {
+        char *c=new char[16];
+        if (val==ActiveSurface::AS_SHAPED) {
+            strcpy(c,"S");
+        }
+        if (val==ActiveSurface::AS_SHAPED_FIXED) {
+            strcpy(c,"SF");
+        }
+        if (val==ActiveSurface::AS_PARABOLIC) {
+            strcpy(c,"P");
+        }
+        if (val==ActiveSurface::AS_PARABOLIC_FIXED) {
+            strcpy(c,"PF");
+        }
+        return c;
+    }
+    static ActiveSurface::TASProfile strToVal(const char* str) throw (ParserErrors::BadTypeFormatExImpl) {
+        IRA::CString strVal(str);
+        strVal.MakeUpper();
+        if (strVal=="S") {
+            return ActiveSurface::AS_SHAPED;
+        }
+        else if (strVal=="SF") {
+            return ActiveSurface::AS_SHAPED_FIXED;
+        }
+        else if (strVal=="P") {
+            return ActiveSurface::AS_PARABOLIC;
+        }
+        else if (strVal=="PF") {
+            return ActiveSurface::AS_PARABOLIC_FIXED;
+        }
+        else {
+            _EXCPT(ParserErrors::BadTypeFormatExImpl,ex,"SRTActiveSurfaceProfile2String::strToVal()");
+            throw ex;
+        }
+    }
 };
 
-SRTActiveSurfaceBossImpl::SRTActiveSurfaceBossImpl(const ACE_CString &CompName, maci::ContainerServices *containerServices) : 
-	CharacteristicComponentImpl(CompName,containerServices),
-	m_pstatus(this),
-	m_penabled(this),
-	m_pprofile(this),
-	m_ptracking(this),
-	m_core(NULL)
-{	
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::SRTActiveSurfaceBossImpl()");
+SRTActiveSurfaceBossImpl::SRTActiveSurfaceBossImpl(const ACE_CString &CompName, maci::ContainerServices *containerServices) :
+    CharacteristicComponentImpl(CompName,containerServices),
+    m_pstatus(this),
+    m_penabled(this),
+    m_pprofile(this),
+    m_ptracking(this),
+    m_core(NULL)
+{
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::SRTActiveSurfaceBossImpl()");
 }
 
 SRTActiveSurfaceBossImpl::~SRTActiveSurfaceBossImpl()
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::~SRTActiveSurfaceBossImpl()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::~SRTActiveSurfaceBossImpl()");
 }
 
 void SRTActiveSurfaceBossImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::initialize()");
-		cs = getContainerServices();
-		//CSRTActiveSurfaceBossCore *boss;
-		ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::initialize()",(LM_INFO,"COMPSTATE_INITIALIZING"));
-	try
-	{
-		boss=(CSRTActiveSurfaceBossCore *)new CSRTActiveSurfaceBossCore(getContainerServices(),this);
-		m_core=new IRA::CSecureArea<CSRTActiveSurfaceBossCore>(boss);
-		m_pstatus=new ROEnumImpl<ACS_ENUM_T(Management::TSystemStatus),POA_Management::ROTSystemStatus>
-			(getContainerServices()->getName()+":status",getComponent(),new SRTActiveSurfaceBossImplDevIOStatus(m_core),true);
-		m_penabled=new ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean>
-			(getContainerServices()->getName()+":enabled",getComponent(),new SRTActiveSurfaceBossImplDevIOEnable(m_core),true);
-		m_pprofile=new ROEnumImpl<ACS_ENUM_T(ActiveSurface::TASProfile),POA_ActiveSurface::ROTASProfile>
-			(getContainerServices()->getName()+":pprofile",getComponent(),new SRTActiveSurfaceBossImplDevIOProfile(m_core),true);
-		m_ptracking=new ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean>
-			(getContainerServices()->getName()+":tracking",getComponent(),new SRTActiveSurfaceBossImplDevIOTracking(m_core),true);
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::initialize()");
+    cs = getContainerServices();
+    ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::initialize()",(LM_INFO,"COMPSTATE_INITIALIZING"));
 
-		// create the parser for command line execution
-		m_parser = new SimpleParser::CParser<CSRTActiveSurfaceBossCore>(boss,10);
-	}
-	catch (std::bad_alloc& ex)
-	{
-		_EXCPT(ComponentErrors::MemoryAllocationExImpl,dummy,"SRTActiveSurfaceBossImpl::initialize()");
-		throw dummy;
-	}
-	boss->initialize();
+    try
+    {
+        boss=(CSRTActiveSurfaceBossCore *)new CSRTActiveSurfaceBossCore(getContainerServices(),this);
+        m_core=new IRA::CSecureArea<CSRTActiveSurfaceBossCore>(boss);
+        m_pstatus=new ROEnumImpl<ACS_ENUM_T(Management::TSystemStatus),POA_Management::ROTSystemStatus>
+            (getContainerServices()->getName()+":status",getComponent(),new SRTActiveSurfaceBossImplDevIOStatus(m_core),true);
+        m_penabled=new ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean>
+            (getContainerServices()->getName()+":enabled",getComponent(),new SRTActiveSurfaceBossImplDevIOEnable(m_core),true);
+        m_pprofile=new ROEnumImpl<ACS_ENUM_T(ActiveSurface::TASProfile),POA_ActiveSurface::ROTASProfile>
+            (getContainerServices()->getName()+":pprofile",getComponent(),new SRTActiveSurfaceBossImplDevIOProfile(m_core),true);
+        m_ptracking=new ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean>
+            (getContainerServices()->getName()+":tracking",getComponent(),new SRTActiveSurfaceBossImplDevIOTracking(m_core),true);
 
-	long workingThreadTime;
-	if (CIRATools::getDBValue(cs,"profile",(long&)m_profile) && CIRATools::getDBValue(cs,"WorkingThreadTime",(long&)workingThreadTime))
-	{
-		ACS_SHORT_LOG((LM_INFO,"SRTActiveSurfaceBoss: CDB %d profile parameter read", m_profile));
-		boss->m_profile = m_profile;
-	}
-	else
-	{
-		ACS_LOG(LM_SOURCE_INFO,"SRTActiveSurfaceBossImpl:initialize()",(LM_ERROR,"Error reading CDB!"));
-		ASErrors::CDBAccessErrorExImpl exImpl(__FILE__,__LINE__,"USDImpl::initialize() - Error reading CDB parameters");
-		throw acsErrTypeLifeCycle::LifeCycleExImpl(exImpl,__FILE__,__LINE__,"USDImpl::initialize()");
-	}
+        // create the parser for command line execution
+        m_parser = new SimpleParser::CParser<CSRTActiveSurfaceBossCore>(boss,10);
+    }
+    catch (std::bad_alloc& ex)
+    {
+        _EXCPT(ComponentErrors::MemoryAllocationExImpl,dummy,"SRTActiveSurfaceBossImpl::initialize()");
+        throw dummy;
+    }
+    boss->initialize();
 
-	try
-	{
-		m_workingThread=getContainerServices()->getThreadManager()->create<CSRTActiveSurfaceBossWorkingThread,CSecureArea<CSRTActiveSurfaceBossCore> *>
-			("SRTACTIVESURFACEBOSSWORKER",m_core);
-		m_workingThread->setSleepTime(workingThreadTime*10);
-	}
-	catch (acsthreadErrType::acsthreadErrTypeExImpl& ex)
-	{
-		_ADD_BACKTRACE(ComponentErrors::ThreadErrorExImpl,_dummy,ex,"SRTActiveSurfaceBossImpl::initialize()");
-		throw _dummy;
-	}
-	catch (...)
-	{
-		_THROW_EXCPT(ComponentErrors::UnexpectedExImpl,"SRTActiveSurfaceBossImpl::initialize()");
-	}
+    long workingThreadTime;
+    if (CIRATools::getDBValue(cs,"profile",(long&)m_profile) && CIRATools::getDBValue(cs,"WorkingThreadTime",(long&)workingThreadTime))
+    {
+        ACS_SHORT_LOG((LM_INFO,"SRTActiveSurfaceBoss: CDB %d profile parameter read", m_profile));
+        boss->m_profile = m_profile;
+    }
+    else
+    {
+        ACS_LOG(LM_SOURCE_INFO,"SRTActiveSurfaceBossImpl:initialize()",(LM_ERROR,"Error reading CDB!"));
+        ASErrors::CDBAccessErrorExImpl exImpl(__FILE__,__LINE__,"USDImpl::initialize() - Error reading CDB parameters");
+        throw acsErrTypeLifeCycle::LifeCycleExImpl(exImpl,__FILE__,__LINE__,"USDImpl::initialize()");
+    }
 
-	for(int sector = 0; sector < SECTORS; sector++)
-	{
-		std::stringstream threadName;
-		threadName << "SRTACTIVESURFACEBOSSSECTOR";
-		threadName << sector+1;
-		try
-		{
-			CSRTActiveSurfaceBossSectorThread* sectorThread = getContainerServices()->getThreadManager()->create<CSRTActiveSurfaceBossSectorThread,CSRTActiveSurfaceBossCore *> (threadName.str().c_str(), boss);
-			sectorThread->setSector(sector);
-			m_sectorThread.push_back(sectorThread);
-		}
-		catch (acsthreadErrType::acsthreadErrTypeExImpl& ex)
-		{
-			_ADD_BACKTRACE(ComponentErrors::ThreadErrorExImpl,_dummy,ex,"SRTActiveSurfaceBossImpl::initialize()");
-			throw _dummy;
-		}
-		catch (...)
-		{
-			_THROW_EXCPT(ComponentErrors::UnexpectedExImpl,"SRTActiveSurfaceBossImpl::initialize()");
-		}
-	}
+    try
+    {
+        m_workingThread=getContainerServices()->getThreadManager()->create<CSRTActiveSurfaceBossWorkingThread,CSecureArea<CSRTActiveSurfaceBossCore> *>("SRTACTIVESURFACEBOSSWORKER",m_core);
+        m_workingThread->setSleepTime(workingThreadTime*10);
+    }
+    catch (acsthreadErrType::acsthreadErrTypeExImpl& ex)
+    {
+        _ADD_BACKTRACE(ComponentErrors::ThreadErrorExImpl,_dummy,ex,"SRTActiveSurfaceBossImpl::initialize()");
+        throw _dummy;
+    }
+    catch (...)
+    {
+        _THROW_EXCPT(ComponentErrors::UnexpectedExImpl,"SRTActiveSurfaceBossImpl::initialize()");
+    }
 
-	// configure the parser.....
-	m_parser->add("asSetup",new function1<CSRTActiveSurfaceBossCore,non_constant,void_type,I<enum_type<SRTActiveSurfaceProfile2String,ActiveSurface::TASProfile> > >(boss,&CSRTActiveSurfaceBossCore::setProfile),1);
-	m_parser->add("asOn",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asOn),0);
-	m_parser->add("asOff",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asOff),0);
-	m_parser->add("asPark",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asPark),0);
+    for(int sector = 0; sector < SECTORS; sector++)
+    {
+        std::stringstream threadName;
+        threadName << "SRTACTIVESURFACEBOSSSECTOR";
+        threadName << sector+1;
+        try
+        {
+            CSRTActiveSurfaceBossSectorThread* sectorThread = getContainerServices()->getThreadManager()->create<CSRTActiveSurfaceBossSectorThread,CSRTActiveSurfaceBossCore *> (threadName.str().c_str(), boss);
+            m_sectorThread.push_back(sectorThread);
+        }
+        catch (acsthreadErrType::acsthreadErrTypeExImpl& ex)
+        {
+            _ADD_BACKTRACE(ComponentErrors::ThreadErrorExImpl,_dummy,ex,"SRTActiveSurfaceBossImpl::initialize()");
+            throw _dummy;
+        }
+        catch (...)
+        {
+            _THROW_EXCPT(ComponentErrors::UnexpectedExImpl,"SRTActiveSurfaceBossImpl::initialize()");
+        }
+    }
 
-	ACS_LOG(LM_FULL_INFO, "SRTActiveSurfaceBossImpl::initialize()", (LM_INFO,"COMPSTATE_INITIALIZED"));
+    // configure the parser.....
+    m_parser->add("asSetup",new function1<CSRTActiveSurfaceBossCore,non_constant,void_type,I<enum_type<SRTActiveSurfaceProfile2String,ActiveSurface::TASProfile> > >(boss,&CSRTActiveSurfaceBossCore::setProfile),1);
+    m_parser->add("asOn",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asOn),0);
+    m_parser->add("asOff",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asOff),0);
+    m_parser->add("asPark",new function0<CSRTActiveSurfaceBossCore,non_constant,void_type >(boss,&CSRTActiveSurfaceBossCore::asPark),0);
+
+    ACS_LOG(LM_FULL_INFO, "SRTActiveSurfaceBossImpl::initialize()", (LM_INFO,"COMPSTATE_INITIALIZED"));
 }
 
 void SRTActiveSurfaceBossImpl::execute() throw (ACSErr::ACSbaseExImpl)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::execute()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::execute()");
 
-	//CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> core=m_core->Get();
-	//core->m_profile = m_profile;
+    try
+    {
+        boss->execute();
+    }
+    catch (ACSErr::ACSbaseExImpl& E)
+    {
+        _ADD_BACKTRACE(ComponentErrors::InitializationProblemExImpl,_dummy,E,"SRTActiveSurfaceBossImpl::execute()");
+        throw _dummy;
+    }
+    m_workingThread->resume();
 
-	try
-	{
-		//core->execute();
-		boss->execute();
-	}
-	catch (ACSErr::ACSbaseExImpl& E)
-	{
-		_ADD_BACKTRACE(ComponentErrors::InitializationProblemExImpl,_dummy,E,"SRTActiveSurfaceBossImpl::execute()");
-		throw _dummy;
-	}
-	//starts the loop working thread....
-	m_workingThread->resume();
+    for(unsigned int i = 0; i < m_sectorThread.size(); i++)
+    {
+        m_sectorThread[i]->setSleepTime(SECTORTIME);
+        m_sectorThread[i]->resume();
+    }
 
-	for(unsigned int i = 0; i < m_sectorThread.size(); i++)
-	{
-		m_sectorThread[i]->setSleepTime(SECTORTIME);
-		m_sectorThread[i]->resume();
-	}
-
-	ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::execute()",(LM_INFO,"SRTActiveSurfaceBossImpl::COMPSTATE_OPERATIONAL"));
+    ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::execute()",(LM_INFO,"SRTActiveSurfaceBossImpl::COMPSTATE_OPERATIONAL"));
 }
 
 void SRTActiveSurfaceBossImpl::cleanUp()
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::cleanUp()");
-	if (m_workingThread!=NULL)
-	{
-		m_workingThread->suspend();
-		getContainerServices()->getThreadManager()->destroy(m_workingThread);
-	}
-	for(unsigned int i = 0; i < m_sectorThread.size(); i++)
-	{
-		if(m_sectorThread[i] != NULL)
-		{
-			m_sectorThread[i]->suspend();
-			getContainerServices()->getThreadManager()->destroy(m_sectorThread[i]);
-		}
-	}
-	ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::cleanUp()",(LM_INFO,"SRTActiveSurfaceBossImpl::THREADS_TERMINATED"));
-	if (m_parser!=NULL) delete m_parser;
-	ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::cleanUp()",(LM_INFO,"SRTActiveSurfaceBossImpl::PARSER_FREED"));
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> core = m_core->Get();
-	core->cleanUp();
-	ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::cleanUp()",(LM_INFO,"SRTActiveSurfaceBossImpl::BOSS_CORE_FREED"));
-	CharacteristicComponentImpl::cleanUp();
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::cleanUp()");
+    if (m_workingThread!=NULL)
+    {
+        m_workingThread->suspend();
+        getContainerServices()->getThreadManager()->destroy(m_workingThread);
+    }
+    for(unsigned int i = 0; i < m_sectorThread.size(); i++)
+    {
+        if(m_sectorThread[i] != NULL)
+        {
+            m_sectorThread[i]->suspend();
+            getContainerServices()->getThreadManager()->destroy(m_sectorThread[i]);
+        }
+    }
+    ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::cleanUp()",(LM_INFO,"SRTActiveSurfaceBossImpl::THREADS_TERMINATED"));
+    if (m_parser!=NULL) delete m_parser;
+    ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::cleanUp()",(LM_INFO,"SRTActiveSurfaceBossImpl::PARSER_FREED"));
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> core = m_core->Get();
+    core->cleanUp();
+    ACS_LOG(LM_FULL_INFO,"SRTActiveSurfaceBossImpl::cleanUp()",(LM_INFO,"SRTActiveSurfaceBossImpl::BOSS_CORE_FREED"));
+    CharacteristicComponentImpl::cleanUp();
 }
 
 void SRTActiveSurfaceBossImpl::aboutToAbort()
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::aboutToAbort()");
-	if (m_workingThread!=NULL)
-	{
-		m_workingThread->suspend();
-		getContainerServices()->getThreadManager()->destroy(m_workingThread);
-	}
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore>  core=m_core->Get(); 
-	core->cleanUp();
-	if (m_parser!=NULL) delete m_parser;
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::aboutToAbort()");
+    if (m_workingThread!=NULL)
+    {
+        m_workingThread->suspend();
+        getContainerServices()->getThreadManager()->destroy(m_workingThread);
+    }
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore>  core=m_core->Get();
+    core->cleanUp();
+    if (m_parser!=NULL) delete m_parser;
 }
 
 void SRTActiveSurfaceBossImpl::stop (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::stop()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::stop()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->onewayAction(ActiveSurface::AS_STOP, circle, actuator, radius, 0, 0, 0, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->onewayAction(ActiveSurface::AS_STOP, circle, actuator, radius, 0, 0, 0, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::setup (const char *config) throw (CORBA::SystemException, ManagementErrors::ConfigurationErrorEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::setup()");
-	IRA::CString strVal(config);
-	strVal.MakeUpper();
-	if (strVal=="S") {
-		setProfile(ActiveSurface::AS_SHAPED);
-	}
-	else if (strVal=="SF") {
-		setProfile(ActiveSurface::AS_SHAPED_FIXED);
-	}
-	else if (strVal=="P") {
-		setProfile(ActiveSurface::AS_PARABOLIC);
-	}
-	else if (strVal=="PF") {
-		setProfile(ActiveSurface::AS_PARABOLIC_FIXED);
-	}
-	else {
-		_EXCPT(ManagementErrors::ConfigurationErrorExImpl,ex,"SRTActiveSurfaceBossImpl::setup()");
-		throw ex.getConfigurationErrorEx();
-	}
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::setup()");
+    IRA::CString strVal(config);
+    strVal.MakeUpper();
+    if (strVal=="S") {
+        setProfile(ActiveSurface::AS_SHAPED);
+    }
+    else if (strVal=="SF") {
+        setProfile(ActiveSurface::AS_SHAPED_FIXED);
+    }
+    else if (strVal=="P") {
+        setProfile(ActiveSurface::AS_PARABOLIC);
+    }
+    else if (strVal=="PF") {
+        setProfile(ActiveSurface::AS_PARABOLIC_FIXED);
+    }
+    else {
+        _EXCPT(ManagementErrors::ConfigurationErrorExImpl,ex,"SRTActiveSurfaceBossImpl::setup()");
+        throw ex.getConfigurationErrorEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::park () throw (CORBA::SystemException, ManagementErrors::ParkingErrorEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::park()");
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->asPark();
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		_EXCPT(ManagementErrors::ParkingErrorExImpl,ex,"SRTActiveSurfaceBossImpl::park()");
-		throw ex.getParkingErrorEx();
-	}
-	resource->m_tracking = false;
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::park()");
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->asPark();
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        _EXCPT(ManagementErrors::ParkingErrorExImpl,ex,"SRTActiveSurfaceBossImpl::park()");
+        throw ex.getParkingErrorEx();
+    }
+    resource->m_tracking = false;
 }
 
 void SRTActiveSurfaceBossImpl::stow (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::stow()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::stow()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->onewayAction(ActiveSurface::AS_STOW, circle, actuator, radius, 0, 0, 0, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->onewayAction(ActiveSurface::AS_STOW, circle, actuator, radius, 0, 0, 0, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::refPos (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::refPos()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::refPos()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->onewayAction(ActiveSurface::AS_REFPOS, circle, actuator, radius, 0, 0, 0, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->onewayAction(ActiveSurface::AS_REFPOS, circle, actuator, radius, 0, 0, 0, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::update (CORBA::Double elevation) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::update()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::update()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-
-	try
-	{
-		resource->onewayAction(ActiveSurface::AS_UPDATE, 0, 0, 0, elevation, 0, 0, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    if(resource->m_profileSetted)
+    {
+        try
+        {
+            resource->onewayAction(ActiveSurface::AS_UPDATE, 0, 0, 0, elevation, 0, 0, m_profile);
+        }
+        catch (ComponentErrors::ComponentErrorsExImpl& ex)
+        {
+            ex.log(LM_DEBUG);
+            throw ex.getComponentErrorsEx();
+        }
+    }
 }
 
 void SRTActiveSurfaceBossImpl::up (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::up()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::up()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->onewayAction(ActiveSurface::AS_UP, circle, actuator, radius, 0, 0, 0, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->onewayAction(ActiveSurface::AS_UP, circle, actuator, radius, 0, 0, 0, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::down (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::down()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::down()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->onewayAction(ActiveSurface::AS_DOWN, circle, actuator, radius, 0, 0, 0, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->onewayAction(ActiveSurface::AS_DOWN, circle, actuator, radius, 0, 0, 0, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::bottom (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::bottom()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::bottom()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->onewayAction(ActiveSurface::AS_BOTTOM, circle, actuator, radius, 0, 0, 0, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->onewayAction(ActiveSurface::AS_BOTTOM, circle, actuator, radius, 0, 0, 0, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::top (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::top()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::top()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->onewayAction(ActiveSurface::AS_TOP, circle, actuator, radius, 0, 0, 0, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->onewayAction(ActiveSurface::AS_TOP, circle, actuator, radius, 0, 0, 0, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::move (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius, CORBA::Long incr) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::move()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::move()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->onewayAction(ActiveSurface::AS_MOVE, circle, actuator, radius, 0, 0, incr, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->onewayAction(ActiveSurface::AS_MOVE, circle, actuator, radius, 0, 0, incr, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::correction (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius, CORBA::Double correction) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::correction()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::correction()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->onewayAction(ActiveSurface::AS_CORRECTION, circle, actuator, radius, 0, correction, 0, m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->onewayAction(ActiveSurface::AS_CORRECTION, circle, actuator, radius, 0, correction, 0, m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::reset (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::reset()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::reset()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->reset(circle, actuator, radius);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->reset(circle, actuator, radius);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::setProfile (ActiveSurface::TASProfile newProfile) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::setProfile()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::setProfile()");
 
-	m_profile = newProfile;
+    m_profile = newProfile;
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->setProfile(m_profile);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->setProfile(m_profile);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::usdStatus4GUIClient (CORBA::Long circle, CORBA::Long actuator, CORBA::Long_out status) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::usdStatus4GUIClient()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::usdStatus4GUIClient()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->usdStatus4GUIClient(circle, actuator, status);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->usdStatus4GUIClient(circle, actuator, status);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::setActuator (CORBA::Long circle, CORBA::Long actuator, CORBA::Long_out actPos, CORBA::Long_out cmdPos, CORBA::Long_out Fmin, CORBA::Long_out Fmax, CORBA::Long_out acc, CORBA::Long_out delay) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::setActuator");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::setActuator");
 
-	long int act, cmd, fmin, fmax, ac, del;
+    long int act, cmd, fmin, fmax, ac, del;
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->setActuator(circle, actuator, act, cmd, fmin, fmax, ac, del);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
-	actPos = (CORBA::Long)act;
-	cmdPos = (CORBA::Long)cmd;
-	Fmin = (CORBA::Long)fmin;
-	Fmax = (CORBA::Long)fmax;
-	acc = (CORBA::Long)ac;
-	delay = (CORBA::Long)del;
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->setActuator(circle, actuator, act, cmd, fmin, fmax, ac, del);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
+    actPos = (CORBA::Long)act;
+    cmdPos = (CORBA::Long)cmd;
+    Fmin = (CORBA::Long)fmin;
+    Fmax = (CORBA::Long)fmax;
+    acc = (CORBA::Long)ac;
+    delay = (CORBA::Long)del;
 }
 
 
 void SRTActiveSurfaceBossImpl::calibrate (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::calibrate()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::calibrate()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->calibrate(circle, actuator, radius);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->calibrate(circle, actuator, radius);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::calVer (CORBA::Long circle, CORBA::Long actuator, CORBA::Long radius) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::calibration verification()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::calibration verification()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->calVer(circle, actuator, radius);
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->calVer(circle, actuator, radius);
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 
 void SRTActiveSurfaceBossImpl::recoverUSD (CORBA::Long circle, CORBA::Long actuator) throw (CORBA::SystemException, ComponentErrors::ComponentErrorsEx)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::recoverUSD()");
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::recoverUSD()");
 
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		//resource->recoverUSD(circle, actuator); TBC!!
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        //resource->recoverUSD(circle, actuator); TBC!!
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::asOn() throw (CORBA::SystemException)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::asOn()");
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->asOn();
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::asOn()");
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->asOn();
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 void SRTActiveSurfaceBossImpl::asOff() throw (CORBA::SystemException)
 {
-	AUTO_TRACE("SRTActiveSurfaceBossImpl::asOff()");
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	try
-	{
-		resource->asOff();
-	}
-	catch (ComponentErrors::ComponentErrorsExImpl& ex)
-	{
-		ex.log(LM_DEBUG);
-		throw ex.getComponentErrorsEx();
-	}
+    AUTO_TRACE("SRTActiveSurfaceBossImpl::asOff()");
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        resource->asOff();
+    }
+    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+    {
+        ex.log(LM_DEBUG);
+        throw ex.getComponentErrorsEx();
+    }
 }
 
 CORBA::Boolean SRTActiveSurfaceBossImpl::command(const char *cmd,CORBA::String_out answer) throw (CORBA::SystemException)
-//char *SRTActiveSurfaceBossImpl::command(const char *cmd) throw (CORBA::SystemException, ManagementErrors::CommandLineErrorEx)
 {
-	AUTO_TRACE("AntennaBossImpl::command()");
-	IRA::CString out;
-	bool res;
-	//IRA::CString in;
-	CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
-	//in=IRA::CString(cmd);
-	try
-	{
-		m_parser->run(cmd,out);
-		res = true;
-	}
-	catch (ParserErrors::ParserErrorsExImpl &ex)
-	{
-		/*_ADD_BACKTRACE(ManagementErrors::CommandLineErrorExImpl,impl,ex,"SRTActiveSurfaceBossImpl::command()");
-		impl.setCommand(cmd);
-		impl.setErrorMessage((const char *)out);
-		impl.log(LM_DEBUG);
-		throw impl.getCommandLineErrorEx();*/
-		res = false;
-	}
-	catch (ACSErr::ACSbaseExImpl& ex)
-	{
-		ex.log(LM_ERROR); // the errors resulting from the execution are logged here as stated in the documentation of CommandInterpreter interface, while the parser errors are never logged.
-		res=false;
-	}
-	answer=CORBA::string_dup((const char *)out);
-	return res;
-	//return CORBA::string_dup((const char *)out);
+    AUTO_TRACE("AntennaBossImpl::command()");
+    IRA::CString out;
+    bool res;
+    CSecAreaResourceWrapper<CSRTActiveSurfaceBossCore> resource=m_core->Get();
+    try
+    {
+        m_parser->run(cmd,out);
+        res = true;
+    }
+    catch (ParserErrors::ParserErrorsExImpl &ex)
+    {
+        res = false;
+    }
+    catch (ACSErr::ACSbaseExImpl& ex)
+    {
+        ex.log(LM_ERROR); // the errors resulting from the execution are logged here as stated in the documentation of CommandInterpreter interface, while the parser errors are never logged.
+        res=false;
+    }
+    answer=CORBA::string_dup((const char *)out);
+    return res;
+    //return CORBA::string_dup((const char *)out);
 }
 
 _PROPERTY_REFERENCE_CPP(SRTActiveSurfaceBossImpl,Management::ROTSystemStatus,m_pstatus,status);

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossSectorThread.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossSectorThread.cpp
@@ -1,41 +1,90 @@
 #include "SRTActiveSurfaceBossSectorThread.h"
 
-CSRTActiveSurfaceBossSectorThread::CSRTActiveSurfaceBossSectorThread(const ACE_CString& name,CSRTActiveSurfaceBossCore *param, 
-            const ACS::TimeInterval& responseTime,const ACS::TimeInterval& sleepTime) : ACS::Thread(name,responseTime,sleepTime)
+CSRTActiveSurfaceBossSectorThread::CSRTActiveSurfaceBossSectorThread(const ACE_CString& name,CSRTActiveSurfaceBossCore *param,
+            const ACS::TimeInterval& responseTime,const ACS::TimeInterval& sleepTime) : ACS::Thread(name,responseTime,sleepTime), m_boss(param)
 {
-    AUTO_TRACE("CSRTActiveSurfaceBossSectorThread::CSRTActiveSurfaceBossSectorThread()");
-    boss = param;
-    m_sector = -1;
+    m_sector = std::atoi(name.substring(name.length()-1).c_str())-1;
+    std::stringstream thread_name;
+    thread_name <<  "CSRTActiveSurfaceBossSector";
+    thread_name << m_sector+1;
+    thread_name << "Thread";
+    m_thread_name = thread_name.str();
+
+    AUTO_TRACE(std::string(m_thread_name + "::CSRTActiveSurfaceBossSectorThread()").c_str());
 }
 
 CSRTActiveSurfaceBossSectorThread::~CSRTActiveSurfaceBossSectorThread()
 {
-    AUTO_TRACE("CSRTActiveSurfaceBossSectorThread::~CSRTActiveSurfaceBossSectorThread()");
+    AUTO_TRACE(std::string(m_thread_name + "::~CSRTActiveSurfaceBossSectorThread()").c_str());
 }
 
 void CSRTActiveSurfaceBossSectorThread::onStart()
 {
-    AUTO_TRACE("CSRTActiveSurfaceBossSectorThread::onStart()");
+    AUTO_TRACE(std::string(m_thread_name + "::onStart()").c_str());
+
+    this->setSleepTime(0); // No sleeping
+
+    TIMEVALUE now;
+    CIRATools::getTime(now);
+    this->timestart = now.value().value;
+
+    std::stringstream table;
+    table << CDBPATH;
+    table << "alma/AS/tab_convUSD_S";
+    table << m_sector+1;
+    table << ".txt";
+
+    m_usdTable.open(table.str().c_str());
+    if (!m_usdTable)
+    {
+        ACS_LOG(LM_SOURCE_INFO,std::string(m_thread_name + "::onStart()").c_str(), (LM_ERROR, "Table file %s not found!", table.str().c_str()));
+        this->setStopped();
+    }
 }
 
 void CSRTActiveSurfaceBossSectorThread::onStop()
 {
-    AUTO_TRACE("CSRTActiveSurfaceBossSectorThread::onStop()");
-}
+    AUTO_TRACE(std::string(m_thread_name + "::onStop()").c_str());
 
-void CSRTActiveSurfaceBossSectorThread::setSector(int sector)
-{
-    m_sector = sector;
-}
-
-void CSRTActiveSurfaceBossSectorThread::run()
-{
-    try
+    if (m_usdTable.is_open())
     {
-        boss->sectorActiveSurface(m_sector);
+        m_usdTable.close();
+        TIMEVALUE now;
+        CIRATools::getTime(now);
+        double elapsed = (double)(now.value().value - this->timestart) / 10000000;
+        ACS_LOG(LM_FULL_INFO,std::string(m_thread_name + "::onStop()").c_str(), (LM_NOTICE, "Total boot time: %.3fs", elapsed));
     }
-    catch (ComponentErrors::ComponentErrorsExImpl& ex)
+}
+
+void CSRTActiveSurfaceBossSectorThread::runLoop()
+{
+    char serial_usd[23];
+    char graf[5], mecc[4];
+    int lanIndex;
+    int circleIndex;
+    int usdCircleIndex;
+
+    if(m_usdTable >> lanIndex >> circleIndex >> usdCircleIndex >> serial_usd >> graf >> mecc)
     {
-        ex.log(LM_DEBUG);
+        ActiveSurface::USD_var current_usd = ActiveSurface::USD::_nil();
+
+        try
+        {
+            current_usd = m_boss->m_services->getComponent<ActiveSurface::USD>(serial_usd);
+        }
+        catch (maciErrType::CannotGetComponentExImpl& ex)
+        {
+            _ADD_BACKTRACE(ComponentErrors::CouldntGetComponentExImpl,Impl,ex,std::string(m_thread_name + "::runLoop()").c_str());
+            Impl.setComponentName(serial_usd);
+            Impl.log(LM_DEBUG);
+        }
+
+        m_boss->lanradius[circleIndex][lanIndex] = m_boss->usd[circleIndex][usdCircleIndex] = current_usd;
+        m_boss->usdCounters[m_sector]++;
+    }
+    else
+    {
+        m_boss->m_sector[m_sector] = true;
+        this->setStopped();
     }
 }

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossWorkingThread.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossWorkingThread.cpp
@@ -29,6 +29,7 @@ void CSRTActiveSurfaceBossWorkingThread::runLoop()
 	TIMEVALUE now;
 	IRA::CIRATools::getTime(now);
 	ACS::Time t0 = now.value().value;
+
 	try
 	{
 		resource->workingActiveSurface();


### PR DESCRIPTION
The `run()` method used to loop to activate all USDs internally, in case the component gets released, the loop prevented the thread from stopping causing a timeout in the release procedure.

Also, the `SRTActiveSurfaceBossImpl.cpp` file was rewritten using a more consistent indentation in order to be easier to read.