### PR TITLE
Fix #497, removed references to SRTActiveSurfaceBossWatchingThread

### DIFF
--- a/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossCore.h
+++ b/SRT/Servers/SRTActiveSurfaceBoss/include/SRTActiveSurfaceBossCore.h
@@ -66,7 +66,7 @@ using namespace ComponentErrors;
 using namespace std;
 
 class SRTActiveSurfaceBossImpl;
-class CSRTActiveSurfaceBossWatchingThread;
+//class CSRTActiveSurfaceBossWatchingThread;
 class CSRTActiveSurfaceBossWorkingThread;
 
 /**
@@ -77,7 +77,7 @@ class CSRTActiveSurfaceBossWorkingThread;
  */
 class CSRTActiveSurfaceBossCore {
     friend class SRTActiveSurfaceBossImpl;
-    friend class CSRTActiveSurfaceBossWatchingThread;
+    //friend class CSRTActiveSurfaceBossWatchingThread;
     friend class CSRTActiveSurfaceBossWorkingThread;
     friend class CSRTActiveSurfaceBossSectorThread;
 public:
@@ -118,7 +118,7 @@ public:
 
     void workingActiveSurface() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx);
 
-    void watchingActiveSurfaceStatus() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::CouldntGetAttributeExImpl, ComponentErrors::ComponentNotActiveExImpl);
+    //void watchingActiveSurfaceStatus() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::CouldntGetAttributeExImpl, ComponentErrors::ComponentNotActiveExImpl);
 
     void usdStatus4GUIClient(int circle, int actuator, CORBA::Long_out status) throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::CouldntGetAttributeExImpl, ComponentErrors::ComponentNotActiveExImpl);
 

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/Makefile
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/Makefile
@@ -83,7 +83,7 @@ LIBRARIES       = SRTActiveSurfaceBossImpl
 LIBRARIES_L     =
 #
 # <brief description of lllll library>
-SRTActiveSurfaceBossImpl_OBJECTS = SRTActiveSurfaceBossImpl SRTActiveSurfaceBossCore SRTActiveSurfaceBossWatchingThread SRTActiveSurfaceBossWorkingThread SRTActiveSurfaceBossSectorThread
+SRTActiveSurfaceBossImpl_OBJECTS = SRTActiveSurfaceBossImpl SRTActiveSurfaceBossCore SRTActiveSurfaceBossWorkingThread SRTActiveSurfaceBossSectorThread
 SRTActiveSurfaceBossImpl_LIBS = lanStubs usdStubs ActiveSurfaceBossStubs SRTActiveSurfaceBossStubs AntennaDefinitionsStubs ManagmentDefinitionsStubs AntennaBossStubs ComponentErrors ASErrors ManagementErrors AntennaErrors IRALibrary ParserErrors DiscosVersion
 
 #

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossCore.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossCore.cpp
@@ -1219,7 +1219,7 @@ void CSRTActiveSurfaceBossCore::onewayAction(ActiveSurface::TASOneWayAction acti
     }
 }
 
-void CSRTActiveSurfaceBossCore::watchingActiveSurfaceStatus() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::CouldntGetAttributeExImpl, ComponentErrors::ComponentNotActiveExImpl)
+/*void CSRTActiveSurfaceBossCore::watchingActiveSurfaceStatus() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::CouldntGetAttributeExImpl, ComponentErrors::ComponentNotActiveExImpl)
 {
     ACS::ROpattern_var status_var;
     ACSErr::Completion_var completion;
@@ -1321,7 +1321,7 @@ void CSRTActiveSurfaceBossCore::watchingActiveSurfaceStatus() throw (ComponentEr
         _THROW_EXCPT(ComponentErrors::ComponentNotActiveExImpl,"CSRTActiveSurfaceBossCore::watchingActiveSurfaceStatus()");
     }
     //printf("NO error\n");
-}
+}*/
 
 void CSRTActiveSurfaceBossCore::workingActiveSurface() throw (ComponentErrors::CORBAProblemExImpl, ComponentErrors::ComponentErrorsEx)
 {


### PR DESCRIPTION
This kind of thread was not used anymore but was compiled alongside the other classes of the SRTActiveSurfaceBoss. I removed any reference but I kept the original files and commented the unnecessary methods in order to keep track of it for eventual future use.