### PR TITLE
Fix #502, removed last service daemon reference from Manager.xml

### DIFF
--- a/SRT/Configuration/CDB/MACI/Managers/Manager/Manager.xml
+++ b/SRT/Configuration/CDB/MACI/Managers/Manager/Manager.xml
@@ -33,7 +33,6 @@
     </ServiceComponents>
 
     <ServiceDaemons>
-        <cdb:_ string="nuraghe-mng.srt.inaf.it"/> 
     </ServiceDaemons>
 
 


### PR DESCRIPTION
The file was in the SRT production CDB. The test CDB, along with other's stations CDBs are ok