### PR TITLE
Fix #506, SRT local oscillators container splitted into multiple ones

### DIFF
--- a/SRT/CDB/MACI/Containers/LocalOscillatorCContainer/LocalOscillatorCContainer.xml
+++ b/SRT/CDB/MACI/Containers/LocalOscillatorCContainer/LocalOscillatorCContainer.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ *  Author Infos
+ *  ============
+ *  Name:         Giuseppe Carboni
+ *  E-mail:       giuseppe.carboni@inaf.it
+-->
+<Container xmlns="urn:schemas-cosylab-com:Container:1.0"
+           xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" 
+           xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" 
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+           xmlns:log="urn:schemas-cosylab-com:LoggingConfig:1.0" 
+           Timeout="30.0"
+           UseIFR="true"
+           ManagerRetry="10"
+           ImplLang="py"
+           Recovery="false">
+
+    <Autoload>
+        <cdb:_ string="baci" />
+    </Autoload>
+
+    <LoggingConfig 
+		centralizedLogger="Log"
+		minLogLevel="5"
+		minLogLevelLocal="5"
+		dispatchPacketSize="0"
+		immediateDispatchLevel="8"
+		flushPeriodSeconds="1"
+	>
+    </LoggingConfig>
+
+</Container>

--- a/SRT/CDB/MACI/Containers/LocalOscillatorKContainer/LocalOscillatorKContainer.xml
+++ b/SRT/CDB/MACI/Containers/LocalOscillatorKContainer/LocalOscillatorKContainer.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ *  Author Infos
+ *  ============
+ *  Name:         Giuseppe Carboni
+ *  E-mail:       giuseppe.carboni@inaf.it
+-->
+<Container xmlns="urn:schemas-cosylab-com:Container:1.0"
+           xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" 
+           xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" 
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+           xmlns:log="urn:schemas-cosylab-com:LoggingConfig:1.0" 
+           Timeout="30.0"
+           UseIFR="true"
+           ManagerRetry="10"
+           ImplLang="py"
+           Recovery="false">
+
+    <Autoload>
+        <cdb:_ string="baci" />
+    </Autoload>
+
+    <LoggingConfig 
+		centralizedLogger="Log"
+		minLogLevel="5"
+		minLogLevelLocal="5"
+		dispatchPacketSize="0"
+		immediateDispatchLevel="8"
+		flushPeriodSeconds="1"
+	>
+    </LoggingConfig>
+
+</Container>

--- a/SRT/Configuration/CDB/MACI/Components/RECEIVERS/LO_CBAND/LO_CBAND.xml
+++ b/SRT/Configuration/CDB/MACI/Components/RECEIVERS/LO_CBAND/LO_CBAND.xml
@@ -11,7 +11,7 @@
 	Name="LO_CBAND"
 	Code="LocalOscillatorImpl.LocalOscillator"
 	Type="IDL:alma/Receivers/LocalOscillator:1.0"
-	Container="LocalOscillatorLPContainer"
+	Container="LocalOscillatorCContainer"
 	KeepAliveTime="10"
 	Default="false"
     ImplLang="py"

--- a/SRT/Configuration/CDB/MACI/Components/RECEIVERS/LO_KBAND/LO_KBAND.xml
+++ b/SRT/Configuration/CDB/MACI/Components/RECEIVERS/LO_KBAND/LO_KBAND.xml
@@ -11,7 +11,7 @@
 	Name="LO_KBAND"
 	Code="LocalOscillatorImpl.LocalOscillator"
 	Type="IDL:alma/Receivers/LocalOscillator:1.0"
-	Container="LocalOscillatorLPContainer"
+	Container="LocalOscillatorKContainer"
 	KeepAliveTime="10"
 	Default="false"
     ImplLang="py"

--- a/SRT/Configuration/CDB/MACI/Containers/LocalOscillatorCContainer/LocalOscillatorCContainer.xml
+++ b/SRT/Configuration/CDB/MACI/Containers/LocalOscillatorCContainer/LocalOscillatorCContainer.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ *  Author Infos
+ *  ============
+ *  Name:         Giuseppe Carboni
+ *  E-mail:       giuseppe.carboni@inaf.it
+-->
+<Container xmlns="urn:schemas-cosylab-com:Container:1.0"
+           xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" 
+           xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" 
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+           xmlns:log="urn:schemas-cosylab-com:LoggingConfig:1.0" 
+           Timeout="30.0"
+           UseIFR="true"
+           ManagerRetry="10"
+           ImplLang="py"
+           Recovery="false">
+
+    <Autoload>
+        <cdb:_ string="baci" />
+    </Autoload>
+
+    <LoggingConfig 
+		centralizedLogger="Log"
+		minLogLevel="5"
+		minLogLevelLocal="5"
+		dispatchPacketSize="0"
+		immediateDispatchLevel="8"
+		flushPeriodSeconds="1"
+	>
+    </LoggingConfig>
+
+</Container>

--- a/SRT/Configuration/CDB/MACI/Containers/LocalOscillatorKContainer/LocalOscillatorKContainer.xml
+++ b/SRT/Configuration/CDB/MACI/Containers/LocalOscillatorKContainer/LocalOscillatorKContainer.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+ *  Author Infos
+ *  ============
+ *  Name:         Giuseppe Carboni
+ *  E-mail:       giuseppe.carboni@inaf.it
+-->
+<Container xmlns="urn:schemas-cosylab-com:Container:1.0"
+           xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" 
+           xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" 
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+           xmlns:log="urn:schemas-cosylab-com:LoggingConfig:1.0" 
+           Timeout="30.0"
+           UseIFR="true"
+           ManagerRetry="10"
+           ImplLang="py"
+           Recovery="false">
+
+    <Autoload>
+        <cdb:_ string="baci" />
+    </Autoload>
+
+    <LoggingConfig 
+		centralizedLogger="Log"
+		minLogLevel="5"
+		minLogLevelLocal="5"
+		dispatchPacketSize="0"
+		immediateDispatchLevel="8"
+		flushPeriodSeconds="1"
+	>
+    </LoggingConfig>
+
+</Container>

--- a/SRT/Misc/SRTScripts/app-defaults/discosStartup.xml
+++ b/SRT/Misc/SRTScripts/app-defaults/discosStartup.xml
@@ -14,7 +14,7 @@
     <toolAgainstInterfaceRepository></toolAgainstInterfaceRepository>
     <toolAgainstNameService></toolAgainstNameService>
     <containers>
-        <select>32</select>
+        <select>34</select>
         <againstManagerHost></againstManagerHost>
         <againstManagerPort></againstManagerPort>
         <againstCDB></againstCDB>
@@ -75,6 +75,24 @@
         </container>
         <container>
             <name>LocalOscillatorLPContainer</name>
+            <type>py</type>
+            <heapSizeMB></heapSizeMB>
+            <useDedicatedSettings>true</useDedicatedSettings>
+            <scriptBase>0</scriptBase>
+            <remoteHost>MASTERHOST</remoteHost>
+            <remoteAccount>discos</remoteAccount>
+        </container>
+        <container>
+            <name>LocalOscillatorCContainer</name>
+            <type>py</type>
+            <heapSizeMB></heapSizeMB>
+            <useDedicatedSettings>true</useDedicatedSettings>
+            <scriptBase>0</scriptBase>
+            <remoteHost>MASTERHOST</remoteHost>
+            <remoteAccount>discos</remoteAccount>
+        </container>
+        <container>
+            <name>LocalOscillatorKContainer</name>
             <type>py</type>
             <heapSizeMB></heapSizeMB>
             <useDedicatedSettings>true</useDedicatedSettings>


### PR DESCRIPTION
This will prevent a single local oscillator component that crashes to bring down the container and other local oscillator instances with it