### PR TITLE
Fix #505, CALMUX integrated into the SRT line.

### DIFF
--- a/SRT/CDB/MACI/Components/BACKENDS/PyCalmux/PyCalmux.xml
+++ b/SRT/CDB/MACI/Components/BACKENDS/PyCalmux/PyCalmux.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Giuseppe Carboni <giuseppe.carboni@inaf.it>
+-->
+
+<Component 
+    xmlns="urn:schemas-cosylab-com:Component:1.0" 
+    xmlns:baci="urn:schemas-cosylab-com:BACI:1.0"
+    xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              
+    Name="PyCalmux"
+    Code="Calmux.PyCalmuxImpl"
+    Type="IDL:alma/Backends/CalMux:1.0"
+    Container="PyCalmuxContainer"
+    ImplLang="py"
+    KeepAliveTime="-1"
+    Default="false"
+/>

--- a/SRT/CDB/MACI/Containers/PyCalmuxContainer/PyCalmuxContainer.xml
+++ b/SRT/CDB/MACI/Containers/PyCalmuxContainer/PyCalmuxContainer.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Container xmlns="urn:schemas-cosylab-com:Container:1.0"
+           xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" 
+           xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" 
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+           xmlns:log="urn:schemas-cosylab-com:LoggingConfig:1.0" 
+           ImplLang="py"
+           Timeout="30.0"
+           UseIFR="true"
+           ManagerRetry="10"
+           Recovery="false">
+
+    <Autoload>
+        <cdb:_ string="baci" />
+    </Autoload>
+
+    <LoggingConfig 
+		centralizedLogger="Log"
+		minLogLevel="5"
+		minLogLevelLocal="5"
+		dispatchPacketSize="0"
+		immediateDispatchLevel="8"
+		flushPeriodSeconds="1"
+	>
+    </LoggingConfig>
+
+</Container>

--- a/SRT/CDB/alma/BACKENDS/PyCalmux/PyCalmux.xml
+++ b/SRT/CDB/alma/BACKENDS/PyCalmux/PyCalmux.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+<!--
+     Giuseppe Carboni, giuseppe.carboni@inaf.it
+-->
+<PyCalmux
+    xmlns="urn:schemas-cosylab-com:PyCalmux:1.0" 
+    xmlns:baci="urn:schemas-cosylab-com:BACI:1.0"
+    xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    IP="127.0.0.1"
+    PORT="12500"/>

--- a/SRT/CDB/alma/DataBlock/PyCalmux/Mapping/Mapping.xml
+++ b/SRT/CDB/alma/DataBlock/PyCalmux/Mapping/Mapping.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+
+<CalMuxTable xmlns="urn:schemas-cosylab-com:CalMuxTable:1.0"
+             	xmlns:baci="urn:schemas-cosylab-com:BACI:1.0"
+				xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0"
+				xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+<BackendEntry><Backend>DBBC</Backend><Channel>6</Channel><Polarity>0</Polarity></BackendEntry>
+
+</CalMuxTable>

--- a/SRT/Configuration/CDB/MACI/Components/BACKENDS/PyCalmux/PyCalmux.xml
+++ b/SRT/Configuration/CDB/MACI/Components/BACKENDS/PyCalmux/PyCalmux.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Giuseppe Carboni <giuseppe.carboni@inaf.it>
+-->
+
+<Component 
+    xmlns="urn:schemas-cosylab-com:Component:1.0" 
+    xmlns:baci="urn:schemas-cosylab-com:BACI:1.0"
+    xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              
+    Name="PyCalmux"
+    Code="Calmux.PyCalmuxImpl"
+    Type="IDL:alma/Backends/CalMux:1.0"
+    Container="PyCalmuxContainer"
+    ImplLang="py"
+    KeepAliveTime="-1"
+    Default="false"
+/>

--- a/SRT/Configuration/CDB/MACI/Containers/PyCalmuxContainer/PyCalmuxContainer.xml
+++ b/SRT/Configuration/CDB/MACI/Containers/PyCalmuxContainer/PyCalmuxContainer.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Container xmlns="urn:schemas-cosylab-com:Container:1.0"
+           xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0" 
+           xmlns:baci="urn:schemas-cosylab-com:BACI:1.0" 
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+           xmlns:log="urn:schemas-cosylab-com:LoggingConfig:1.0" 
+           ImplLang="py"
+           Timeout="30.0"
+           UseIFR="true"
+           ManagerRetry="10"
+           Recovery="false">
+
+    <Autoload>
+        <cdb:_ string="baci" />
+    </Autoload>
+
+    <LoggingConfig 
+		centralizedLogger="Log"
+		minLogLevel="5"
+		minLogLevelLocal="5"
+		dispatchPacketSize="0"
+		immediateDispatchLevel="8"
+		flushPeriodSeconds="1"
+	>
+    </LoggingConfig>
+
+</Container>

--- a/SRT/Configuration/CDB/alma/BACKENDS/PyCalmux/PyCalmux.xml
+++ b/SRT/Configuration/CDB/alma/BACKENDS/PyCalmux/PyCalmux.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+<!--
+     Giuseppe Carboni, giuseppe.carboni@inaf.it
+-->
+<PyCalmux
+    xmlns="urn:schemas-cosylab-com:PyCalmux:1.0" 
+    xmlns:baci="urn:schemas-cosylab-com:BACI:1.0"
+    xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    IP="192.168.200.123"
+    PORT="5003"/>

--- a/SRT/Configuration/CDB/alma/DataBlock/PyCalmux/Mapping/Mapping.xml
+++ b/SRT/Configuration/CDB/alma/DataBlock/PyCalmux/Mapping/Mapping.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+
+<CalMuxTable xmlns="urn:schemas-cosylab-com:CalMuxTable:1.0"
+             	xmlns:baci="urn:schemas-cosylab-com:BACI:1.0"
+				xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0"
+				xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+<BackendEntry><Backend>DBBC</Backend><Channel>6</Channel><Polarity>0</Polarity></BackendEntry>
+
+</CalMuxTable>

--- a/SystemMake/Makefile
+++ b/SystemMake/Makefile
@@ -34,7 +34,7 @@ COMMON_LIBRARIES:=SlaLibrary IRALibrary DiscosVersion TextWindowLibrary ParserLi
 COMMON_SERVERS:=AntennaBoss Observatory OTF PointingModel Refraction SkySource \
                 Moon FitsWriter Scheduler ReceiversBoss ExternalClients \
                 CalibrationTool TotalPower NoiseGenerator CustomLogger \
-                XBackend PyDewarPositioner Sardara PyLocalOscillator MFKBandBaseReceiver
+                XBackend PyDewarPositioner Sardara PyLocalOscillator MFKBandBaseReceiver PyCalmux
 COMMON_CLIENTS:=AntennaBossTextClient ObservatoryTextClient \
                 GenericBackendTextClient ReceiversBossTextClient \
                 SystemTerminal CaltoolClient CustomLoggingClient \


### PR DESCRIPTION
For now the only tested and working backend is the DBBC. The DFB should be integrated soon, I'll handle its integration with others SRT operating team members.

Also, `PyCalmux` component has been added to the `SystemMake` file for automatic build and install (somehow we forgot about it when we installed it in Noto).