### PR TITLE
fix issue #515: fixed that Managment container crash when logger comp…

### DIFF
--- a/Common/Servers/Scheduler/include/Core.h
+++ b/Common/Servers/Scheduler/include/Core.h
@@ -68,8 +68,10 @@ public:
 	 * @throw ComponentErrors::TimerErrorExImpl
 	 * @throw ComponentErrors::CouldntGetComponentExImpl
 	 * @thorw ManagementErrors::ProcedureFileLoadingErrorExImpl
+	 * @throw ComponentErrors::UnexpectedExImpl
 	*/
-	virtual void execute() throw (ComponentErrors::TimerErrorExImpl,ComponentErrors::CouldntGetComponentExImpl,ComponentErrors::MemoryAllocationExImpl,ManagementErrors::ProcedureFileLoadingErrorExImpl);
+	virtual void execute() throw (ComponentErrors::TimerErrorExImpl,ComponentErrors::CouldntGetComponentExImpl,ComponentErrors::MemoryAllocationExImpl,
+	  ManagementErrors::ProcedureFileLoadingErrorExImpl,ComponentErrors::UnexpectedExImpl);
 	
 	/**
 	 * This function initializes the core, all preliminary operation are performed here.
@@ -132,7 +134,7 @@ private:
 	/**
 	 * pointer to the configuration object
 	 */
-	 CConfiguration*  m_config;
+	 CConfiguration* m_config;
 	/**
 	 * pointer to the container services
 	 */

--- a/Common/Servers/Scheduler/include/Core_Resource.h
+++ b/Common/Servers/Scheduler/include/Core_Resource.h
@@ -27,7 +27,8 @@
 									m_antennaRTime=new Antenna::TRunTimeParameters; m_antennaRTime->targetName=""; \
 									m_antennaRTime->axis=Management::MNG_NO_AXIS; \
 									m_servoRunTime=new MinorServo::TRunTimeParameters; m_servoRunTime->scanAxis=""; \
-									m_subScanConf.signal=Management::MNG_SIGNAL_NONE;
+									m_subScanConf.signal=Management::MNG_SIGNAL_NONE; \
+									m_parser=NULL;
 
 
 									
@@ -45,18 +46,11 @@
 					  ACS_LOG(LM_FULL_INFO, "Core::execute()", (LM_INFO,"RECEIVERS_NC_READY")); \
 					  m_defaultBackendInstance=m_config->getDefaultBackendInstance(); \
 					  m_defaultDataReceiverInstance=m_config->getDefaultDataReceiverInstance(); \
-					  try { \
-					  	m_parser=new CParser<CCore>(this,10,true);\
-					  } \
-					  catch (...) { \
-						_EXCPT(ComponentErrors::MemoryAllocationExImpl,dummy,"CCore::execute()"); \
-						throw dummy; \
-	                  } \
-	                  if (!m_timer.init()) { \
+	              if (!m_timer.init()) { \
 		                _EXCPT(ComponentErrors::TimerErrorExImpl,dummy,"CCore::initialize()"); \
 		                 dummy.setReason("Timer could not be initialized"); \
 		                throw dummy; \
-	                  }
+	              }
 
 #define RESOURCE_CLEANUP if (m_antennaNC!=NULL) m_antennaNC->disconnect(); \
 						 m_antennaNC=NULL; \

--- a/Common/Servers/Scheduler/include/SchedulerImpl.h
+++ b/Common/Servers/Scheduler/include/SchedulerImpl.h
@@ -81,7 +81,7 @@ public:
 	 * logs the COMPSTATE_OPERATIONAL
 	 * @throw ACSErr::ACSbaseExImpl
 	*/
-	virtual void execute() throw (ACSErr::ACSbaseExImpl);
+	virtual void execute();
 	
 	/** 
 	 * Called by the container before destroying the server in a normal situation. This function takes charge of 

--- a/Common/Servers/Scheduler/src/Core.cpp
+++ b/Common/Servers/Scheduler/src/Core.cpp
@@ -29,7 +29,9 @@ void CCore::initialize()
 	m_lastWeatherTime=0;
 }
 
-void CCore::execute() throw (ComponentErrors::TimerErrorExImpl,ComponentErrors::CouldntGetComponentExImpl,ComponentErrors::MemoryAllocationExImpl,ManagementErrors::ProcedureFileLoadingErrorExImpl)
+void CCore::execute() throw (ComponentErrors::TimerErrorExImpl,ComponentErrors::CouldntGetComponentExImpl,
+  ComponentErrors::MemoryAllocationExImpl,ManagementErrors::ProcedureFileLoadingErrorExImpl,
+  ComponentErrors::UnexpectedExImpl)
 {
 	Antenna::TSiteInformation_var site;
 	Antenna::Observatory_var observatory=Antenna::Observatory::_nil();
@@ -51,6 +53,8 @@ void CCore::execute() throw (ComponentErrors::TimerErrorExImpl,ComponentErrors::
 		Impl.setComponentName((const char*)m_config->getObservatoryComponent());
 		throw Impl;				
 	}
+	/*catch (...) {
+	}*/
 	ACS_LOG(LM_FULL_INFO,"CCore::execute()",(LM_INFO,"OBSERVATORY_LOCATED"));	
 	try	{	
 		site=observatory->getSiteSummary();  //throw CORBA::SYSTEMEXCEPTION
@@ -72,8 +76,9 @@ void CCore::execute() throw (ComponentErrors::TimerErrorExImpl,ComponentErrors::
 		Impl.setComponentName((const char*)observatory->name());
 		throw Impl;
 	}
-	RESOURCE_EXEC;
 	loadCustomLogger(m_customLogger,m_customLoggerError); // throw ComponentErrors::CouldntGetComponentExImpl
+	
+	RESOURCE_EXEC;
 
 	// spawn schedule executor thread........
 	try {
@@ -90,6 +95,14 @@ void CCore::execute() throw (ComponentErrors::TimerErrorExImpl,ComponentErrors::
 	m_schedExecuter->initialize(m_services,m_dut1,m_site,m_config); // throw (ComponentErrors::TimerErrorExImpl)
 	ACS::TimeInterval sleepTime=m_config->getScheduleExecutorSleepTime()*10;
 	m_schedExecuter->setSleepTime(sleepTime);
+
+   try {
+		m_parser=new CParser<CCore>(this,10,true);\
+	}
+	catch (...) {
+		_EXCPT(ComponentErrors::MemoryAllocationExImpl,dummy,"CCore::execute()");
+		throw dummy;
+	}
 
 	//add local commands
 	m_parser->add("tsys",new function1<CCore,non_constant,void_type,O<doubleSeq_type> >(this,&CCore::_callTSys),0);

--- a/Common/Servers/Scheduler/src/Core_Operations.i
+++ b/Common/Servers/Scheduler/src/Core_Operations.i
@@ -523,11 +523,11 @@ void CCore::_fTrack(const char *dev) throw (ComponentErrors::CouldntGetComponent
 		impl.setComponentName(backend->name());
 		throw impl;
 	}
-	for (unsigned t=0;t<bckinputFreq->length();t++) {
+	/*for (unsigned t=0;t<bckinputFreq->length();t++) {
 		printf("bck freq :%lf\n",bckinputFreq[t]);
 		printf("bck bw:%lf\n",bckinputBW[t]);
 
-	}
+	}*/
 	if (inputSection->length()!=(unsigned)inputs) {
 		_EXCPT(ComponentErrors::ValidationErrorExImpl,impl,"CCore::_fTrack()");
 		impl.setReason("inconsistent data from the backend inputs number");
@@ -535,7 +535,7 @@ void CCore::_fTrack(const char *dev) throw (ComponentErrors::CouldntGetComponent
 	}
 	//---------------------------------------------------------------------------------------------------
 	//4) info from antenna--------------------------------------------------------------------------------
-	printf("RestFrequency : %lf\n",m_restFrequency[0]);
+	//printf("RestFrequency : %lf\n",m_restFrequency[0]);
 	try {
 		m_antennaBoss->getTopocentricFrequency(m_restFrequency,topocentricFreq.out());
 	}
@@ -563,7 +563,7 @@ void CCore::_fTrack(const char *dev) throw (ComponentErrors::CouldntGetComponent
 		_EXCPT(ComponentErrors::UnexpectedExImpl,impl,"CCore::_fTrack()");
 		throw impl;
 	}
-	for (unsigned t=0;t<topocentricFreq->length();t++) printf("topocentric Freq :%lf\n",topocentricFreq[t]);
+	//for (unsigned t=0;t<topocentricFreq->length();t++) printf("topocentric Freq :%lf\n",topocentricFreq[t]);
 	// just to make sure the topocentric sequence has the right dimension!
 	if (topocentricFreq->length()!=m_restFrequency.length()) {
 		topocentricFreq->length(m_restFrequency.length());
@@ -580,7 +580,7 @@ void CCore::_fTrack(const char *dev) throw (ComponentErrors::CouldntGetComponent
 		throw impl;
 	}
 	IFNumber=IFNumberRO->get_sync(comp.out()); // number of output IFs of the receeever
-	printf("if number :%ld\n",IFNumber);
+	//printf("if number :%ld\n",IFNumber);
 	try {
 		m_receiversBoss->getIFOutput(bckinputFeed,bckinputIF,fndoutputFreq.out(),fndoutputBw.out(),fndoutputPol.out(),fndoutputLO.out());
 	}
@@ -607,10 +607,10 @@ void CCore::_fTrack(const char *dev) throw (ComponentErrors::CouldntGetComponent
 		impl.setReason("inconsistent data from the receivers if outputs");
 		throw impl;
 	}
-	for (unsigned t=0;t<fndoutputFreq->length();t++) {
+	/*for (unsigned t=0;t<fndoutputFreq->length();t++) {
 		printf("Frequency :%lf\n",fndoutputFreq[t]);
 		printf("BandWidth :%lf\n",fndoutputBw[t]);
-	}
+	}*/
 	//---------------------------------------------------------------------------------------------------
 	//5) let's start with some computations  -----------------------------------------------------------------------------
 	sectionFreq.length(sections);
@@ -621,16 +621,16 @@ void CCore::_fTrack(const char *dev) throw (ComponentErrors::CouldntGetComponent
 		inputLO[j]=fndoutputLO[j]; //if (device=="BCK")
 		if ((device=="ALL") || (device=="LO")) {
 			currentSection=inputSection[j];
-			printf("currentSection :%ld\n",currentSection);
+			//printf("currentSection :%ld\n",currentSection);
 			if (topocentricFreq->length()==1) {
 				inputLO[j]=IRA::CIRATools::roundNearest(topocentricFreq[0]-bckinputFreq[j]-
 						(bckinputBW[j]/2.0),digits);
-				printf("inputLO[j] :%lf\n",inputLO[j]);
+				//printf("inputLO[j] :%lf\n",inputLO[j]);
 			}
 			else {
 				inputLO[j]=IRA::CIRATools::roundNearest(topocentricFreq[currentSection]-bckinputFreq[j]-
 						(bckinputBW[j]/2.0),digits);
-				printf("inputLO[j] :%lf\n",inputLO[j]);
+				//printf("inputLO[j] :%lf\n",inputLO[j]);
 			}
 			//lo[bckinputIF[j]]=inputLO[j]; // local oscillator per IFs
 		}
@@ -644,7 +644,7 @@ void CCore::_fTrack(const char *dev) throw (ComponentErrors::CouldntGetComponent
 			if (bckinputIF[i]==j) {
 				if((lo[j] < 0.0 ) || (inputLO[i] < lo[j])) { // change the local oscillator value if ......
 					lo[j] = inputLO[i];
-					printf("lo changed: #if: %ld, value: %lf  \n",j,lo[j]);
+					//printf("lo changed: #if: %ld, value: %lf  \n",j,lo[j]);
 				}
 			}
 		}

--- a/Common/Servers/Scheduler/src/Core_Resource.i
+++ b/Common/Servers/Scheduler/src/Core_Resource.i
@@ -247,16 +247,19 @@ void CCore::loadCustomLogger(Management::CustomLogger_var& ref,bool& errorDetect
 			ACS_LOG(LM_FULL_INFO,"CCore::loadCustomLogger()",(LM_INFO,"CUSTOMLOGGER_LOCATED"));
 		}
 		catch (maciErrType::CannotGetComponentExImpl& ex) {
+			ref=Management::CustomLogger::_nil();
 			_ADD_BACKTRACE(ComponentErrors::CouldntGetComponentExImpl,Impl,ex,"CCore::loadCustomLogger()");
 			Impl.setComponentName((const char*)m_config->getCustomLoggerComponent());
 			throw Impl;
 		}
 		catch (maciErrType::NoPermissionExImpl& ex) {
+			ref=Management::CustomLogger::_nil();
 			_ADD_BACKTRACE(ComponentErrors::CouldntGetComponentExImpl,Impl,ex,"CCore::loadCustomLogger()");
 			Impl.setComponentName((const char*)m_config->getCustomLoggerComponent());
 			throw Impl;
 		}
 		catch (maciErrType::NoDefaultComponentExImpl& ex) {
+			ref=Management::CustomLogger::_nil();
 			_ADD_BACKTRACE(ComponentErrors::CouldntGetComponentExImpl,Impl,ex,"CCore::loadCustomLogger()");
 			Impl.setComponentName((const char*)m_config->getCustomLoggerComponent());
 			throw Impl;

--- a/Common/Servers/Scheduler/src/SchedulerImpl.cpp
+++ b/Common/Servers/Scheduler/src/SchedulerImpl.cpp
@@ -71,15 +71,14 @@ void SchedulerImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 	ACS_LOG(LM_FULL_INFO,"SchedulerImpl::initialize()",(LM_INFO,"COMPSTATE_INITIALIZED"));
 }
 
-void SchedulerImpl::execute() throw (ACSErr::ACSbaseExImpl)
+void SchedulerImpl::execute()
 {
 	AUTO_TRACE("SchedulerImpl::execute()");
-	_IRA_LOGFILTER_ACTIVATE(m_config.getRepetitionCacheTime(),m_config.getRepetitionExpireTime());
 	try {
 		m_core->execute();
 	}
 	catch (ACSErr::ACSbaseExImpl& E) {
-		_ADD_BACKTRACE(ComponentErrors::InitializationProblemExImpl,_dummy,E,"SchedulerImpl::execute()");
+		_ADD_BACKTRACE(ComponentErrors::InitializationProblemExImpl,_dummy,E,"SchedulerImpl::execute()");		
 		throw _dummy;
 	}
 	try {
@@ -93,6 +92,7 @@ void SchedulerImpl::execute() throw (ACSErr::ACSbaseExImpl)
 		_ADD_BACKTRACE(ComponentErrors::ThreadErrorExImpl,__dummy,E,"SchedulerImpl::execute()");
 		throw __dummy;		
 	}
+	_IRA_LOGFILTER_ACTIVATE(m_config.getRepetitionCacheTime(),m_config.getRepetitionExpireTime());
 	ACS_LOG(LM_FULL_INFO,"SchedulerImpl::execute()",(LM_INFO,"COMPSTATE_OPERATIONAL"));
 }
 


### PR DESCRIPTION
…onent is not available. Also some random printf commented out.

The problem was related (probably) to memory issue in NC creation (consumer side). The object destruction is not properly handled when exiting (with an exception) in the execute method. 
I just postponed the NC creation after all the other activities in execute method are completed. 