### PR TITLE
Fix issue #525

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,4 +90,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/
 
 ## Fixed
     issue #518 - In case of communication error we set a dummy value (100000) for the temperature properties, and the related timestamp keeps the value of the last communication timestamp.
+    issue #525 - When in LOCAL mode the receivers can turn on/off the noise mark. There is no more MNG_FAILURE logging in case of LOCAL mode: only the initial status (during component startup) and the change of status (local to remote and viceversa) are written to the logfile.
 ## Changed    

--- a/Common/Servers/MFKBandBaseReceiver/src/MFKBandBaseCore.cpp
+++ b/Common/Servers/MFKBandBaseReceiver/src/MFKBandBaseCore.cpp
@@ -71,6 +71,22 @@ CConfiguration const * const  CComponentCore::execute() throw (
     }
     m_localOscillatorValue=0.0;
     m_setupMode="";
+
+    if(m_control->isRemoteOn()) {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::updateIsRemote()",
+            "RECEVER_REMOTELY_CONTROLLABLE"
+        );
+    }
+    else {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::updateIsRemote()",
+            "RECEVER_NOT_REMOTELY_CONTROLLABLE"
+        );
+    }
+
     return &m_configuration;
 }
 
@@ -985,6 +1001,22 @@ void CComponentCore::updateIsRemote() throw (ReceiversErrors::ReceiverControlBoa
         setStatusBit(CONNECTIONERROR);
         throw impl;
     }
+
+    if (checkStatusBit(LOCAL) && answer) {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::updateIsRemote()",
+            "RECEVER_SWITCHED_FROM_LOCAL_TO_REMOTE"
+        );
+    }
+    else if (!checkStatusBit(LOCAL) && !answer) {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::updateIsRemote()",
+            "RECEVER_SWITCHED_FROM_REMOTE_TO_LOCAL"
+        );
+    }
+
     if (!answer) setStatusBit(LOCAL);
     else clearStatusBit(LOCAL);
     clearStatusBit(CONNECTIONERROR); // the communication was ok so clear the CONNECTIONERROR bit

--- a/Common/Servers/MFKBandBaseReceiver/src/MFKBandBaseCore.cpp
+++ b/Common/Servers/MFKBandBaseReceiver/src/MFKBandBaseCore.cpp
@@ -188,10 +188,10 @@ void CComponentCore::externalCalOn() throw (
         throw impl;
     }
     guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOn()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOn()");
+    //     throw impl;
+    // }
     try {
         m_control->setExtCalibrationOn();
     }
@@ -227,10 +227,10 @@ void CComponentCore::externalCalOff() throw (
         throw impl;
     }
     guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOff()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOff()");
+    //     throw impl;
+    // }
     try {
         m_control->setExtCalibrationOff();
     }
@@ -277,10 +277,10 @@ void CComponentCore::calOn() throw (
         throw impl;
     }
     // guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOn()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOn()");
+    //     throw impl;
+    // }
     try {
         m_control->setCalibrationOn();
         m_calDiode=true;
@@ -317,10 +317,10 @@ void CComponentCore::calOff() throw (
         throw impl;
     }
     // guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOff()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOff()");
+    //     throw impl;
+    // }
     try {
         m_control->setCalibrationOff();
         m_calDiode=false;
@@ -834,10 +834,10 @@ void CComponentCore::updateComponent()
 {
     baci::ThreadSyncGuard guard(&m_mutex);
     m_componentStatus=Management::MNG_OK;
-    if (checkStatusBit(LOCAL)) {
-        setComponentStatus(Management::MNG_FAILURE);
-        _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEVER_NOT_REMOTELY_CONTROLLABLE");
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     setComponentStatus(Management::MNG_FAILURE);
+    //     _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEVER_NOT_REMOTELY_CONTROLLABLE");
+    // }
     if (checkStatusBit(VACUUMPUMPFAULT)) {
         setComponentStatus(Management::MNG_WARNING);
         _IRA_LOGFILTER_LOG(LM_WARNING,"CComponentCore::updateComponent()","VACUUM_PUMP_FAILURE");

--- a/Common/Servers/MFKBandBaseReceiver/src/MFKBandBaseCore.cpp
+++ b/Common/Servers/MFKBandBaseReceiver/src/MFKBandBaseCore.cpp
@@ -75,14 +75,14 @@ CConfiguration const * const  CComponentCore::execute() throw (
     if(m_control->isRemoteOn()) {
         _IRA_LOGFILTER_LOG(
             LM_INFO,
-            "CComponentCore::updateIsRemote()",
+            "CComponentCore::execute()",
             "RECEVER_REMOTELY_CONTROLLABLE"
         );
     }
     else {
         _IRA_LOGFILTER_LOG(
             LM_INFO,
-            "CComponentCore::updateIsRemote()",
+            "CComponentCore::execute()",
             "RECEVER_NOT_REMOTELY_CONTROLLABLE"
         );
     }

--- a/Common/Servers/MFKBandBaseReceiver/src/MFKBandBaseCore.cpp
+++ b/Common/Servers/MFKBandBaseReceiver/src/MFKBandBaseCore.cpp
@@ -76,14 +76,14 @@ CConfiguration const * const  CComponentCore::execute() throw (
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::execute()",
-            "RECEVER_REMOTELY_CONTROLLABLE"
+            "RECEIVER_REMOTELY_CONTROLLABLE"
         );
     }
     else {
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::execute()",
-            "RECEVER_NOT_REMOTELY_CONTROLLABLE"
+            "RECEIVER_NOT_REMOTELY_CONTROLLABLE"
         );
     }
 
@@ -852,7 +852,7 @@ void CComponentCore::updateComponent()
     m_componentStatus=Management::MNG_OK;
     // if (checkStatusBit(LOCAL)) {
     //     setComponentStatus(Management::MNG_FAILURE);
-    //     _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEVER_NOT_REMOTELY_CONTROLLABLE");
+    //     _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEIVER_NOT_REMOTELY_CONTROLLABLE");
     // }
     if (checkStatusBit(VACUUMPUMPFAULT)) {
         setComponentStatus(Management::MNG_WARNING);
@@ -1006,14 +1006,14 @@ void CComponentCore::updateIsRemote() throw (ReceiversErrors::ReceiverControlBoa
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::updateIsRemote()",
-            "RECEVER_SWITCHED_FROM_LOCAL_TO_REMOTE"
+            "RECEIVER_SWITCHED_FROM_LOCAL_TO_REMOTE"
         );
     }
     else if (!checkStatusBit(LOCAL) && !answer) {
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::updateIsRemote()",
-            "RECEVER_SWITCHED_FROM_REMOTE_TO_LOCAL"
+            "RECEIVER_SWITCHED_FROM_REMOTE_TO_LOCAL"
         );
     }
 

--- a/SRT/Servers/SRT7GHzReceiver/src/ComponentCore.cpp
+++ b/SRT/Servers/SRT7GHzReceiver/src/ComponentCore.cpp
@@ -65,6 +65,21 @@ CConfiguration const * const  CComponentCore::execute() throw (ComponentErrors::
         m_localOscillatorValue=m_configuration.getDefaultLO()[i];
     }
     m_setupMode="";
+
+    if(m_control->isRemoteOn()) {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::execute()",
+            "RECEVER_REMOTELY_CONTROLLABLE"
+        );
+    }
+    else {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::execute()",
+            "RECEVER_NOT_REMOTELY_CONTROLLABLE"
+        );
+    }
     return &m_configuration;
 }
 
@@ -162,10 +177,10 @@ void CComponentCore::externalCalOn() throw (
         throw impl;
     }
     guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOn()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOn()");
+    //     throw impl;
+    // }
     try {
         m_control->setExtCalibrationOn();
     }
@@ -202,10 +217,10 @@ void CComponentCore::externalCalOff() throw (
         throw impl;
     }
     guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOff()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOff()");
+    //     throw impl;
+    // }
     try {
         m_control->setExtCalibrationOff();
     }
@@ -274,10 +289,10 @@ void CComponentCore::calOn() throw (ReceiversErrors::NoRemoteControlErrorExImpl,
         throw impl;
     }
     // guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOn()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOn()");
+    //     throw impl;
+    // }
     try {
         m_control->setCalibrationOn();
     }
@@ -301,10 +316,10 @@ void CComponentCore::calOff() throw (ReceiversErrors::NoRemoteControlErrorExImpl
         throw impl;
     }
     // guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOff()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOff()");
+    //     throw impl;
+    // }
     try {
         m_control->setCalibrationOff();
     }
@@ -698,10 +713,10 @@ void CComponentCore::updateComponent()
 {
     baci::ThreadSyncGuard guard(&m_mutex);
     m_componentStatus=Management::MNG_OK;
-    if (checkStatusBit(LOCAL)) {
-        setComponentStatus(Management::MNG_FAILURE);
-        _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEVER_NOT_REMOTELY_CONTROLLABLE");
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     setComponentStatus(Management::MNG_FAILURE);
+    //     _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEVER_NOT_REMOTELY_CONTROLLABLE");
+    // }
     if (checkStatusBit(VACUUMPUMPFAULT)) {
         setComponentStatus(Management::MNG_WARNING);
         _IRA_LOGFILTER_LOG(LM_WARNING,"CComponentCore::updateComponent()","VACUUM_PUMP_FAILURE");
@@ -837,6 +852,22 @@ void CComponentCore::updateIsRemote() throw (ReceiversErrors::ReceiverControlBoa
         setStatusBit(CONNECTIONERROR);
         throw impl;
     }
+
+    if (checkStatusBit(LOCAL) && answer) {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::updateIsRemote()",
+            "RECEVER_SWITCHED_FROM_LOCAL_TO_REMOTE"
+        );
+    }
+    else if (!checkStatusBit(LOCAL) && !answer) {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::updateIsRemote()",
+            "RECEVER_SWITCHED_FROM_REMOTE_TO_LOCAL"
+        );
+    }
+
     if (!answer) setStatusBit(LOCAL);
     else clearStatusBit(LOCAL);
     clearStatusBit(CONNECTIONERROR); // the communication was ok so clear the CONNECTIONERROR bit

--- a/SRT/Servers/SRT7GHzReceiver/src/ComponentCore.cpp
+++ b/SRT/Servers/SRT7GHzReceiver/src/ComponentCore.cpp
@@ -70,14 +70,14 @@ CConfiguration const * const  CComponentCore::execute() throw (ComponentErrors::
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::execute()",
-            "RECEVER_REMOTELY_CONTROLLABLE"
+            "RECEIVER_REMOTELY_CONTROLLABLE"
         );
     }
     else {
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::execute()",
-            "RECEVER_NOT_REMOTELY_CONTROLLABLE"
+            "RECEIVER_NOT_REMOTELY_CONTROLLABLE"
         );
     }
     return &m_configuration;
@@ -715,7 +715,7 @@ void CComponentCore::updateComponent()
     m_componentStatus=Management::MNG_OK;
     // if (checkStatusBit(LOCAL)) {
     //     setComponentStatus(Management::MNG_FAILURE);
-    //     _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEVER_NOT_REMOTELY_CONTROLLABLE");
+    //     _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEIVER_NOT_REMOTELY_CONTROLLABLE");
     // }
     if (checkStatusBit(VACUUMPUMPFAULT)) {
         setComponentStatus(Management::MNG_WARNING);
@@ -857,14 +857,14 @@ void CComponentCore::updateIsRemote() throw (ReceiversErrors::ReceiverControlBoa
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::updateIsRemote()",
-            "RECEVER_SWITCHED_FROM_LOCAL_TO_REMOTE"
+            "RECEIVER_SWITCHED_FROM_LOCAL_TO_REMOTE"
         );
     }
     else if (!checkStatusBit(LOCAL) && !answer) {
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::updateIsRemote()",
-            "RECEVER_SWITCHED_FROM_REMOTE_TO_LOCAL"
+            "RECEIVER_SWITCHED_FROM_REMOTE_TO_LOCAL"
         );
     }
 

--- a/SRT/Servers/SRTLPBandReceiver/src/ComponentCore.cpp
+++ b/SRT/Servers/SRTLPBandReceiver/src/ComponentCore.cpp
@@ -70,6 +70,22 @@ CConfiguration const * const  CComponentCore::execute() throw (
     
     m_localOscillatorValue = m_configuration.getDefaultLO()[0];
     m_actualMode="";
+
+    if(m_control->isRemoteOn()) {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::execute()",
+            "RECEVER_REMOTELY_CONTROLLABLE"
+        );
+    }
+    else {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::execute()",
+            "RECEVER_NOT_REMOTELY_CONTROLLABLE"
+        );
+    }
+
     return &m_configuration;
 }
 
@@ -237,10 +253,10 @@ void CComponentCore::externalCalOn() throw (
         throw impl;
     }
     guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOn()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOn()");
+    //     throw impl;
+    // }
     try {
         m_control->setExtCalibrationOn();
     }
@@ -277,10 +293,10 @@ void CComponentCore::externalCalOff() throw (
         throw impl;
     }
     guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOff()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOff()");
+    //     throw impl;
+    // }
     try {
         m_control->setExtCalibrationOff();
     }
@@ -324,10 +340,10 @@ void CComponentCore::calOn() throw (
         throw impl;
     }
     // guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOn()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOn()");
+    //     throw impl;
+    // }
     try {
         m_control->setCalibrationOn();
 		  m_calDiode=true;    
@@ -364,10 +380,10 @@ void CComponentCore::calOff() throw (
         throw impl;
     }
     // guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOff()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOff()");
+    //     throw impl;
+    // }
     try {
         m_control->setCalibrationOff();
         m_calDiode=false;
@@ -1082,6 +1098,22 @@ void CComponentCore::updateIsRemote() throw (ReceiversErrors::ReceiverControlBoa
         setStatusBit(CONNECTIONERROR);
         throw impl;
     }
+
+    if (checkStatusBit(LOCAL) && answer) {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::updateIsRemote()",
+            "RECEVER_SWITCHED_FROM_LOCAL_TO_REMOTE"
+        );
+    }
+    else if (!checkStatusBit(LOCAL) && !answer) {
+        _IRA_LOGFILTER_LOG(
+            LM_INFO,
+            "CComponentCore::updateIsRemote()",
+            "RECEVER_SWITCHED_FROM_REMOTE_TO_LOCAL"
+        );
+    }
+
     if (!answer) {
         setStatusBit(LOCAL);
     }

--- a/SRT/Servers/SRTLPBandReceiver/src/ComponentCore.cpp
+++ b/SRT/Servers/SRTLPBandReceiver/src/ComponentCore.cpp
@@ -75,14 +75,14 @@ CConfiguration const * const  CComponentCore::execute() throw (
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::execute()",
-            "RECEVER_REMOTELY_CONTROLLABLE"
+            "RECEIVER_REMOTELY_CONTROLLABLE"
         );
     }
     else {
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::execute()",
-            "RECEVER_NOT_REMOTELY_CONTROLLABLE"
+            "RECEIVER_NOT_REMOTELY_CONTROLLABLE"
         );
     }
 
@@ -949,10 +949,10 @@ void CComponentCore::updateComponent()
 {
     baci::ThreadSyncGuard guard(&m_mutex);
     m_componentStatus=Management::MNG_OK;
-    if (checkStatusBit(LOCAL)) {
-        setComponentStatus(Management::MNG_FAILURE);
-        _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEVER_NOT_REMOTELY_CONTROLLABLE");
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     setComponentStatus(Management::MNG_FAILURE);
+    //     _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEIVER_NOT_REMOTELY_CONTROLLABLE");
+    // }
     if (checkStatusBit(VACUUMPUMPFAULT)) {
         setComponentStatus(Management::MNG_WARNING);
         _IRA_LOGFILTER_LOG(LM_WARNING,"CComponentCore::updateComponent()","VACUUM_PUMP_FAILURE");
@@ -1103,14 +1103,14 @@ void CComponentCore::updateIsRemote() throw (ReceiversErrors::ReceiverControlBoa
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::updateIsRemote()",
-            "RECEVER_SWITCHED_FROM_LOCAL_TO_REMOTE"
+            "RECEIVER_SWITCHED_FROM_LOCAL_TO_REMOTE"
         );
     }
     else if (!checkStatusBit(LOCAL) && !answer) {
         _IRA_LOGFILTER_LOG(
             LM_INFO,
             "CComponentCore::updateIsRemote()",
-            "RECEVER_SWITCHED_FROM_REMOTE_TO_LOCAL"
+            "RECEIVER_SWITCHED_FROM_REMOTE_TO_LOCAL"
         );
     }
 


### PR DESCRIPTION
The Labviw program turns on and off the mark also in `LOCAL` mode, so these changes are supposed to work also for the DISCOS component, but to be sure I prefere to test the component using the real board.