### PR TITLE
Fix #525, enabled receivers control when set to LOCAL mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,4 +90,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/
 
 ## Fixed
     issue #518 - In case of communication error we set a dummy value (100000) for the temperature properties, and the related timestamp keeps the value of the last communication timestamp.
+    issue #525 - When in LOCAL mode the receivers can turn on/off the noise mark and LNAs. There is no more MNG_FAILURE logging in case of LOCAL mode: only the LOCAL/REMOTE status (during component activation) and the change of status (LOCAL to REMOTE and viceversa) are written to the logfile.
 ## Changed    

--- a/SRT/Servers/SRTLPBandReceiver/src/ComponentCore.cpp
+++ b/SRT/Servers/SRTLPBandReceiver/src/ComponentCore.cpp
@@ -222,6 +222,25 @@ void CComponentCore::activate(const char * setup_mode) throw (
     guard.release();
     lnaOn(); // Throw (ReceiversErrors::NoRemoteControlErrorExImpl,ReceiversErrors::ReceiverControlBoardErrorExImpl)
     externalCalOff();
+
+    bool answer;
+    try {
+        answer=m_control->isRemoteOn();
+    }
+    catch (IRA::ReceiverControlEx& ex) {
+        _EXCPT(ReceiversErrors::ReceiverControlBoardErrorExImpl,impl,"CComponentCore::activate()");
+        impl.setDetails(ex.what().c_str());
+        setStatusBit(CONNECTIONERROR);
+        throw impl;
+    }
+    if (answer) {
+        _IRA_LOGFILTER_LOG(LM_NOTICE, "CComponentCore::activate()", "RECEIVER_COMMUNICATION_MODE_REMOTE");
+        clearStatusBit(LOCAL);
+    }
+    else {
+        _IRA_LOGFILTER_LOG(LM_NOTICE, "CComponentCore::activate()", "RECEIVER_COMMUNICATION_MODE_LOCAL");
+        setStatusBit(LOCAL);
+    }
 }
 
 
@@ -237,10 +256,10 @@ void CComponentCore::externalCalOn() throw (
         throw impl;
     }
     guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOn()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOn()");
+    //     throw impl;
+    // }
     try {
         m_control->setExtCalibrationOn();
     }
@@ -277,10 +296,10 @@ void CComponentCore::externalCalOff() throw (
         throw impl;
     }
     guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOff()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::externalCalOff()");
+    //     throw impl;
+    // }
     try {
         m_control->setExtCalibrationOff();
     }
@@ -324,10 +343,10 @@ void CComponentCore::calOn() throw (
         throw impl;
     }
     // guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOn()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOn()");
+    //     throw impl;
+    // }
     try {
         m_control->setCalibrationOn();
 		  m_calDiode=true;    
@@ -364,10 +383,10 @@ void CComponentCore::calOff() throw (
         throw impl;
     }
     // guard.release();
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOff()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::calOff()");
+    //     throw impl;
+    // }
     try {
         m_control->setCalibrationOff();
         m_calDiode=false;
@@ -440,10 +459,10 @@ void CComponentCore::lnaOff() throw (
         ReceiversErrors::ReceiverControlBoardErrorExImpl
         )
 {
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::lnaOff()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::lnaOff()");
+    //     throw impl;
+    // }
     try {
         m_control-> turnRightLNAsOff();
         m_control-> turnLeftLNAsOff();
@@ -463,10 +482,10 @@ void CComponentCore::lnaOn() throw (
         ReceiversErrors::ReceiverControlBoardErrorExImpl
         )
 {
-    if (checkStatusBit(LOCAL)) {
-        _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::lnaOn()");
-        throw impl;
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     _EXCPT(ReceiversErrors::NoRemoteControlErrorExImpl,impl,"CComponentCore::lnaOn()");
+    //     throw impl;
+    // }
     try {
         m_control-> turnRightLNAsOn();
         m_control-> turnLeftLNAsOn();
@@ -933,10 +952,10 @@ void CComponentCore::updateComponent()
 {
     baci::ThreadSyncGuard guard(&m_mutex);
     m_componentStatus=Management::MNG_OK;
-    if (checkStatusBit(LOCAL)) {
-        setComponentStatus(Management::MNG_FAILURE);
-        _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEVER_NOT_REMOTELY_CONTROLLABLE");
-    }
+    // if (checkStatusBit(LOCAL)) {
+    //     setComponentStatus(Management::MNG_FAILURE);
+    //     _IRA_LOGFILTER_LOG(LM_CRITICAL,"CComponentCore::updateComponent()","RECEIVER_NOT_REMOTELY_CONTROLLABLE");
+    // }
     if (checkStatusBit(VACUUMPUMPFAULT)) {
         setComponentStatus(Management::MNG_WARNING);
         _IRA_LOGFILTER_LOG(LM_WARNING,"CComponentCore::updateComponent()","VACUUM_PUMP_FAILURE");
@@ -1082,6 +1101,22 @@ void CComponentCore::updateIsRemote() throw (ReceiversErrors::ReceiverControlBoa
         setStatusBit(CONNECTIONERROR);
         throw impl;
     }
+
+    if (checkStatusBit(LOCAL) && answer) {
+        _IRA_LOGFILTER_LOG(
+            LM_NOTICE,
+            "CComponentCore::updateIsRemote()",
+            "RECEIVER_SWITCHED_FROM_LOCAL_TO_REMOTE"
+        );
+    }
+    else if (!checkStatusBit(LOCAL) && !answer) {
+        _IRA_LOGFILTER_LOG(
+            LM_NOTICE,
+            "CComponentCore::updateIsRemote()",
+            "RECEIVER_SWITCHED_FROM_REMOTE_TO_LOCAL"
+        );
+    }
+
     if (!answer) {
         setStatusBit(LOCAL);
     }


### PR DESCRIPTION
* Fix issue #525

* Logging remote/local

* Fix issue for LBand and CBand

* Fixed a typo (RECEVER to RECEIVER)

* Removed isRemoteOn() check at startup

* No check on turnLNAon()

* Remove the lnaOn/Off LOCAL check

* REMOTE/LOCAL log message during activation

* LNAs can be turned on/off in LOCAL mode

* INFO to NOTICE log level

* Check answer->isRemote() at startup