### PR TITLE
Fix #651, removed the Calmux sleep time when sending a command

### DIFF
--- a/Common/Servers/PyCalmux/src/Calmux/PyCalmuxImpl.py
+++ b/Common/Servers/PyCalmux/src/Calmux/PyCalmuxImpl.py
@@ -146,8 +146,6 @@ class PyCalmuxImpl(CalMux, cc, services, lcycle):
 
         s.sendall(command)
 
-        time.sleep(0.1)
-
         response = s.recv(1024)
         s.close()
         response = response.strip().split()


### PR DESCRIPTION
This modification was tested on the field and it seems to be working fine.