### PR TITLE
Fix #672, fix #637, some improvements for the SRTMinorServoCommandLibrary

### DIFF
--- a/SRT/Libraries/SRTMinorServoLibrary/include/SRTMinorServoCommandLibrary.h
+++ b/SRT/Libraries/SRTMinorServoLibrary/include/SRTMinorServoCommandLibrary.h
@@ -22,10 +22,10 @@ class SRTMinorServoCommandLibrary
 public:
     /**
      * Builds the command used to ask the status of the MSCU or, eventually, a single servo
-     * @param servo_id the ID number of the eventual single servo to retrieve the status
+     * @param servo_id the ID string of the eventual single servo to retrieve the status
      * @return the composed message
      */
-    static std::string status(int servo_id = -1);
+    static std::string status(std::string servo_id = "");
 
     /**
      * Builds the command used to configure the telescope for an observation
@@ -36,37 +36,45 @@ public:
 
     /*
      * Builds the command used to stow a single servo system to a given stow position
-     * @param servo_id the ID number of the single servo to be stowed
+     * @param servo_id the ID string of the single servo to be stowed
      * @param stow_position the position to which the servo have to stow to
      * @return the composed message
      */
-    static std::string stow(unsigned int servo_id, unsigned int stow_position = 0);
+    static std::string stow(std::string servo_id, unsigned int stow_position = 0);
 
     /*
      * Builds the command used to stop a single servo system
-     * @param servo_id the ID number of the single servo to be stopped
+     * @param servo_id the ID string of the single servo to be stopped
      * @return the composed message
      */
-    static std::string stop(unsigned int servo_id);
+    static std::string stop(std::string servo_id);
 
     /*
      * Builds the command used to move a single servo to a given set of coordinates
-     * @param servo_id the ID number of the single servo to be moved
+     * @param servo_id the ID string of the single servo to be moved
      * @param coordinates a vector containing the N coordinates to be sent to the servo
      * @return the composed message
      */
-    static std::string preset(unsigned int servo_id, std::vector<double> coordinates);
+    static std::string preset(std::string servo_id, std::vector<double> coordinates);
 
     /*
      * Builds the command used to provide a single tracking set of coordinates to a single servo
-     * @param servo_id the ID number of the single servo to send the command to
+     * @param servo_id the ID string of the single servo to send the command to
      * @param trajectory_id the ID number of the trajectory the given set of coordinates belongs to
      * @param point_id the ID number of the given set of coordinates inside the trajectory
      * @param coordinates a vector containing the N coordinates the servo have to move to at the given time
      * @param start_time only mandatory for the first point in the trajectory, a double representing the UNIX epoch of the starting instant of the trajectory
      * @return the composed message
      */
-    static std::string programTrack(unsigned int servo_id, unsigned int trajectory_id, unsigned int point_id, std::vector<double> coordinates, double start_time = -1);
+    static std::string programTrack(std::string servo_id, long unsigned int trajectory_id, unsigned int point_id, std::vector<double> coordinates, double start_time = 0);
+
+    /*
+     * Builds the command used to send a set of offset coordinates
+     * @param servo_id the ID string of the single servo to send the offsets to
+     * @param coordinates a vector containing the N offsets to be added the servo coordinates
+     * @return the composed message
+     */
+    static std::string offset(std::string servo_id, std::vector<double> coordinates);
 };
 
 #endif

--- a/SRT/Libraries/SRTMinorServoLibrary/src/Makefile
+++ b/SRT/Libraries/SRTMinorServoLibrary/src/Makefile
@@ -23,7 +23,7 @@ USER_CFLAGS = -Wall
 #
 # additional include and library search paths
 # USER_INC = /usr/local/include
-USER_LIB = -lgsl -lgslcblas -lm
+USER_LIB =
 
 #
 # MODULE CODE DESCRIPTION:
@@ -35,11 +35,15 @@ USER_LIB = -lgsl -lgslcblas -lm
 # C programs (public and local)
 # -----------------------------
 EXECUTABLES     =
-EXECUTABLES_L   = 
+EXECUTABLES_L   = TestSRTMinorServoCommandLibrary
+
+TestSRTMinorServoCommandLibrary_OBJECTS   = TestSRTMinorServoCommandLibrary
+TestSRTMinorServoCommandLibrary_CFLAGS    = -std=c++0x
+TestSRTMinorServoCommandLibrary_LIBS      = SRTMinorServoCommandLibrary IRALibrary
 
 #
 # <brief description of xxxxx program>
-xxxxx_OBJECTS   =	
+xxxxx_OBJECTS   =
 xxxxx_LDFLAGS   =
 xxxxx_LIBS      =
 
@@ -58,7 +62,7 @@ INCLUDES        = hexlib.h SRTMinorServoCommandLibrary.h
 LIBRARIES       = SRTMinorServoLibrary SRTMinorServoCommandLibrary
 LIBRARIES_L     =
 SRTMinorServoLibrary_OBJECTS = hexlib
-SRTMinorServoLibrary_LIBS =
+SRTMinorServoLibrary_LIBS = gsl gslcblas m
 SRTMinorServoCommandLibrary_OBJECTS = SRTMinorServoCommandLibrary
 SRTMinorServoCommandLibrary_LIBS = IRALibrary
 

--- a/SRT/Libraries/SRTMinorServoLibrary/src/SRTMinorServoCommandLibrary.cpp
+++ b/SRT/Libraries/SRTMinorServoLibrary/src/SRTMinorServoCommandLibrary.cpp
@@ -6,69 +6,81 @@
 
 #include "SRTMinorServoCommandLibrary.h"
 
-std::string SRTMinorServoCommandLibrary::status(int servo_id)
+std::string SRTMinorServoCommandLibrary::status(std::string servo_id)
 {
     std::stringstream command;
-    command << "status";
-    if(servo_id >= 0)
+    command << "STATUS";
+    if(servo_id != "")
     {
         command << "=" << servo_id;
     }
-    command << std::endl;
+    command << "\r\n";
     return command.str();
 }
 
 std::string SRTMinorServoCommandLibrary::setup(std::string configuration)
 {
     std::stringstream command;
-    command << "setup=" << configuration << std::endl;
+    command << "SETUP=" << configuration << "\r\n";
     return command.str();
 }
 
-std::string SRTMinorServoCommandLibrary::stow(unsigned int servo_id, unsigned int stow_position)
+std::string SRTMinorServoCommandLibrary::stow(std::string servo_id, unsigned int stow_position)
 {
     std::stringstream command;
-    command << "stow=" << servo_id << "," << stow_position << std::endl;
+    command << "STOW=" << servo_id << "," << stow_position << "\r\n";
     return command.str();
 }
 
-std::string SRTMinorServoCommandLibrary::stop(unsigned int servo_id)
+std::string SRTMinorServoCommandLibrary::stop(std::string servo_id)
 {
     std::stringstream command;
-    command << "stop=" << servo_id << std::endl;
+    command << "STOP=" << servo_id << "\r\n";
     return command.str();
 }
 
-std::string SRTMinorServoCommandLibrary::preset(unsigned int servo_id, std::vector<double> coordinates)
+std::string SRTMinorServoCommandLibrary::preset(std::string servo_id, std::vector<double> coordinates)
 {
     std::stringstream command;
-    command << "preset=" << servo_id;
+    command << "PRESET=" << servo_id;
     for(unsigned int coordinate = 0; coordinate < coordinates.size(); coordinate++)
     {
         command << "," << coordinates[coordinate];
     }
-    command << std::endl;
+    command << "\r\n";
     return command.str();
 }
 
-std::string SRTMinorServoCommandLibrary::programTrack(unsigned int servo_id, unsigned int trajectory_id, unsigned int point_id, std::vector<double> coordinates, double start_time)
+std::string SRTMinorServoCommandLibrary::programTrack(std::string servo_id, long unsigned int trajectory_id, unsigned int point_id, std::vector<double> coordinates, double start_time)
 {
     std::stringstream command;
-    command << "programTrack=" << servo_id << "," << trajectory_id << "," << point_id << ",";
+    command << "PROGRAMTRACK=" << servo_id << "," << trajectory_id << "," << point_id << ",";
     if(start_time > 0)
     {
-        command << std::fixed << std::setprecision(6) << start_time;
+        long unsigned int start_time_int = (long unsigned int)(start_time * 1000);
+        command << start_time_int;
     }
     else
     {
         command << "*";
     }
     
-    command.unsetf(std::ios_base::floatfield);
     for(unsigned int coordinate = 0; coordinate < coordinates.size(); coordinate++)
     {
         command << "," << coordinates[coordinate];
     }
-    command << std::endl;
+    command << "\r\n";
+    return command.str();
+}
+
+std::string SRTMinorServoCommandLibrary::offset(std::string servo_id, std::vector<double> coordinates)
+{
+    std::stringstream command;
+    command << "OFFSET=" << servo_id;
+    for(unsigned int coordinate = 0; coordinate < coordinates.size(); coordinate++)
+    {
+        command << "," << coordinates[coordinate];
+    }
+    command << "\r\n";
     return command.str();
 }

--- a/SRT/Libraries/SRTMinorServoLibrary/src/TestSRTMinorServoCommandLibrary.cpp
+++ b/SRT/Libraries/SRTMinorServoLibrary/src/TestSRTMinorServoCommandLibrary.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include "SRTMinorServoCommandLibrary.h"
+
+using namespace IRA;
+
+int main(void)
+{
+    // Skipping std::endl since the protocol adds a \n already
+    std::cout << SRTMinorServoCommandLibrary::status();
+    std::cout << SRTMinorServoCommandLibrary::status("SRP");
+    std::cout << SRTMinorServoCommandLibrary::setup("CCB");
+    std::cout << SRTMinorServoCommandLibrary::stow("PFP");
+    std::cout << SRTMinorServoCommandLibrary::stow("PFP", 1);
+    std::cout << SRTMinorServoCommandLibrary::stop("PFP");
+    std::cout << SRTMinorServoCommandLibrary::preset("PFP", std::vector<double>{0.,1.,2.,3.,4.,5.});
+
+    double start_time = CIRATools::getUNIXEpoch() + 3;
+    long unsigned int trajectory_id = (long unsigned int)(start_time * 1000);
+    std::cout << SRTMinorServoCommandLibrary::programTrack("PFP", trajectory_id, 0, std::vector<double>{0.,1.,2.,3.,4.,5.}, start_time);
+    for(unsigned int i = 1; i < 10; i++)
+    {
+        std::cout << SRTMinorServoCommandLibrary::programTrack("PFP", trajectory_id, i, std::vector<double>{0.,1.,2.,3.,4.,5.});
+    }
+
+    std::cout << SRTMinorServoCommandLibrary::offset("PFP", std::vector<double>{0.,1.,2.,3.,4.,5.});
+}


### PR DESCRIPTION
Fix #672, wrote all the commands in capital letters
Fix #673, added the OFFSET command to the library
Also:
Changed the start_time parameter of the programTrack function to be written as an integer.
Fixed the closing characters for each command.
Changed the servo_id argument from integer to string.
Added a test executable.
Fixed some small issues in the Makefile.