### PR TITLE
Fix #677, changed config for ExternalClients and RFIMonitoring in testing CDB

### DIFF
--- a/SRT/CDB/alma/MANAGEMENT/RFIMonitoring/RFIMonitoring.xml
+++ b/SRT/CDB/alma/MANAGEMENT/RFIMonitoring/RFIMonitoring.xml
@@ -3,15 +3,15 @@
    - History:
    -   Wed Apr 13 15:18:03 UTC 2005 modified by Carlo Migoni
 -->
-<ExternalClients xmlns="urn:schemas-cosylab-com:ExternalClients:1.0" 
+<RFIMonitoring xmlns="urn:schemas-cosylab-com:RFIMonitoring:1.0"
                  xmlns:baci="urn:schemas-cosylab-com:BACI:1.0"
                  xmlns:cdb="urn:schemas-cosylab-com:CDB:1.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  IPAddress="0.0.0.0"
-                 Port="30000"
-		 ReceiveTimeout="10000000"
+                 Port="40000"
+		         ReceiveTimeout="10000000"
                  ControlThreadPeriod="10000000"
                  SuperVisor="Gavino">
                
-	<status description="The status of the external client component" />
-</ExternalClients>
+	<status description="The status of the RFI monitoring component" />
+</RFIMonitoring>


### PR DESCRIPTION
This applies only to SRT CDB, the configuration can be changed for Medicina and Noto as well