### PR TITLE
Fix #700, IRAPy now imports Connection class, not module

### DIFF
--- a/Common/Libraries/IRALibrary/src/IRAPy/__init__.py
+++ b/Common/Libraries/IRALibrary/src/IRAPy/__init__.py
@@ -11,7 +11,7 @@ list of modules:
 """
 import customlogging
 import ACSLog
-import Connection
+from Connection import Connection
 
 #Some comments required here. The custom logger mechanism is not working in python. 
 #do the way to separate the system logs to the ones do be shown to the user is to use different


### PR DESCRIPTION
This will fix the PyCalmux component behavior