### PR TITLE
Increased log level in WeatherStation Container #691

### DIFF
--- a/SRT/CDB/MACI/Containers/WeatherStationContainer/WeatherStationContainer.xml
+++ b/SRT/CDB/MACI/Containers/WeatherStationContainer/WeatherStationContainer.xml
@@ -7,5 +7,5 @@
 	<Autoload>
 		<cdb:_ string="baci" />
 	</Autoload>
-	<LoggingConfig centralizedLogger="Log" minLogLevel="2" minLogLevelLocal="2" dispatchPacketSize="0" immediateDispatchLevel="8" flushPeriodSeconds="1" />
+	<LoggingConfig centralizedLogger="Log" minLogLevel="5" minLogLevelLocal="5" dispatchPacketSize="0" immediateDispatchLevel="8" flushPeriodSeconds="1" />
 </Container>


### PR DESCRIPTION
low log levels generate floods in acs stdout files and in jlog for test CDB. Increased min log level from 2 (DEBUG) to 5 (NOTICE)