### PR TITLE
fix issue #722: in case that the first subscan of a scan has no recor…

### DIFF
--- a/Common/Servers/Scheduler/src/ScheduleExecutor.cpp
+++ b/Common/Servers/Scheduler/src/ScheduleExecutor.cpp
@@ -4,9 +4,11 @@
 
 using namespace baci;
 
-#define NORMAL_RECORDING (m_currentScan.backendProc!=_SCHED_NULLTARGET) && (m_currentScan.duration>0.0)
+#define BCKEND_CONFIG (m_currentScan.backendProc!=_SCHED_NULLTARGET)
+#define NORMAL_RECORDING BCKEND_CONFIG && (m_currentScan.duration>0.0)
 #define NO_RECORDING m_currentScan.duration<=0.0
 #define DRY_RUN (m_currentScan.backendProc==_SCHED_NULLTARGET) && (m_currentScan.duration>0.0)
+ 
 
 CScheduleExecutor::CScheduleExecutor(const ACE_CString& name,CCore *param, 
 			const ACS::TimeInterval& responseTime,const ACS::TimeInterval& sleepTime) : ACS::Thread(name,responseTime,sleepTime)
@@ -142,7 +144,7 @@ void CScheduleExecutor::runLoop()
 				catch (ACSErr::ACSbaseExImpl& ex) {
 					_ADD_BACKTRACE(ManagementErrors::SubscanErrorExImpl,impl,ex,"CScheduleExecutor::runLoop()");
 					impl.setSubScanID(m_scheduleCounter);
-					impl.setReason("cannot check scan against telescope");
+					impl.setReason("scan cannot be validated");
 					m_core->changeSchedulerStatus(Management::MNG_FAILURE);
 					//impl.log(LM_ERROR);
 					CUSTOM_EXCPT_LOG(impl,LM_ERROR);
@@ -178,7 +180,7 @@ void CScheduleExecutor::runLoop()
 							if (m_schedule->getSchedReps()>0) { // if negative the schedule is repeated continuosly
 								if (m_repetition>=(DWORD)m_schedule->getSchedReps()) { // END OF SCHEDULE
 									CUSTOM_LOG(LM_FULL_INFO,"CScheduleExecutor::runLoop()",
-									  (LM_NOTICE,"All repetions are completed, schedule will be halted"));
+									  (LM_NOTICE,"All repetitions are completed, schedule will be halted"));
 									cleanSchedule(false);
 									break;
 								}
@@ -894,7 +896,7 @@ void CScheduleExecutor::prepareFileWriting(/*const CSchedule::TRecord& rec*/) th
  			m_core->disableDataTransfer();
 		}
 	}
- 	if (NORMAL_RECORDING) { // if the writing has been disabled
+ 	if (BCKEND_CONFIG) { // if the writing has been disabled
  	 	if (m_currentScan.backendProc!=m_currentBackendProcedure) {
  	 		ACS_LOG(LM_FULL_INFO,"CScheduleExecutor::prepareFileWriting()",(LM_DEBUG,"NEW_BACKEND_PROCEDURE"));
  	 		if (!m_schedule->getBackendList()->getBackend(m_currentScan.backendProc,bckInstance,command)) {
@@ -908,7 +910,7 @@ void CScheduleExecutor::prepareFileWriting(/*const CSchedule::TRecord& rec*/) th
  	 		m_currentBackendProcedure=m_currentScan.backendProc;
  	 	}
 	 	m_core->_chooseDefaultDataRecorder(m_currentScan.writerInstance); //CouldntGetComponentExImpl ComponentErrors::UnexpectedExImpl
- 	 	m_core->enableDataTransfer();
+ 	 	if (NORMAL_RECORDING) m_core->enableDataTransfer();
  	}
  	else {
  		m_currentBackendProcedure=_SCHED_NULLTARGET;


### PR DESCRIPTION
…ding time is now hadle properly. I.E. the backend configuration procedure is done even if

the recording is not setup.