### PR TITLE
fix issue #621: introduced a check right before the schedule file par…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,4 +99,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/
 ## Fixed
 ## Changed
 	 issue #689 - The dataset provided by wether station has been enlarged by the wind direction. The correctponding RAL 'wx' command will noe provided wind direction readout, as well
-    issue #621 - The maiumun numeber of chars of the schedule file name is now 37 (extension included). This is done for fits file and archive issue with the lenght of the schedule name.
+    issue #621 - The maximum number of chars of the schedule file name is now 37 (extension included). This is done for fits file and archive issue with the lenght of the schedule name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,4 +99,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/
 ## Fixed
 ## Changed
 	 issue #689 - The dataset provided by wether station has been enlarged by the wind direction. The correctponding RAL 'wx' command will noe provided wind direction readout, as well
-
+    issue #621 - The maiumun numeber of chars of the schedule file name is now 37 (extension included). This is done for fits file and archive issue with the lenght of the schedule name.

--- a/Common/Servers/Scheduler/include/Schedule.h
+++ b/Common/Servers/Scheduler/include/Schedule.h
@@ -25,6 +25,7 @@
 
 #define _SCHED_NULLTARGET "NULL"
 #define SEPARATOR '\t'
+#define MAX_SCHED_NAME_LEN 37
 
 /**
  * This namespace contains all the classes and symbol that are needed to parse and execute the schedules

--- a/Common/Servers/Scheduler/src/Schedule.cpp
+++ b/Common/Servers/Scheduler/src/Schedule.cpp
@@ -111,6 +111,10 @@ CBaseSchedule::~CBaseSchedule()
 bool CBaseSchedule::readAll(bool check)
 {
 	IRA::CString err;
+	if (m_fileName.GetLength()>MAX_SCHED_NAME_LEN) {
+		m_lastError.Format("Schedule name exceeds the maximum allowed characters of %d",MAX_SCHED_NAME_LEN);
+		return false;
+	}
 	if (!m_parser->open(m_fileName)) {
 		m_lastError.Format("Cannot open file %s",(const char *)m_fileName);
 		return false;


### PR DESCRIPTION
…sing, if the length of the file name is longer than maximum the

parsing is aborted and an error returned. These same check is done also by the scheudle checker.