### PR TITLE
Fix #739, updated Sardara port in SRT testing CDB

### DIFF
--- a/SRT/CDB/alma/BACKENDS/Sardara/Sardara.xml
+++ b/SRT/CDB/alma/BACKENDS/Sardara/Sardara.xml
@@ -9,7 +9,7 @@
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                sender_protocols="TCP=${HOST}:14000"
                IPAddress="127.0.0.1"
-               Port="12800"
+               Port="12801"
                CommandLineTimeout="100000000"
                ConnectTimeout="300000000"
                PropertyRefreshTime="1000000"


### PR DESCRIPTION
Due to recent changes in the simulators package (Mistral backend implementation addition), the Sardara simulator port has changed, so it had to be updated in the CDB as well