### PR TITLE
Fix #769, update for CGG 8.3.1

### DIFF
--- a/Common/Servers/FitsWriter/src/FitsTools.cpp
+++ b/Common/Servers/FitsWriter/src/FitsTools.cpp
@@ -60,7 +60,7 @@ CCfits::Table *CFitsTools::createTable(CCfits::FITS *const fits,const IRA::CStri
 	CCfits::Table *table;
 	if (!fits) {
 		errorMessage="fits file is not created";
-		return false;
+		return NULL;
 	}
 	try {
 		table=fits->addTable((const char *)name,0,colName,colForm,colUnit);

--- a/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossSectorThread.cpp
+++ b/SRT/Servers/SRTActiveSurfaceBoss/src/SRTActiveSurfaceBossSectorThread.cpp
@@ -58,8 +58,7 @@ void CSRTActiveSurfaceBossSectorThread::onStop()
 
 void CSRTActiveSurfaceBossSectorThread::runLoop()
 {
-    char serial_usd[23];
-    char graf[5], mecc[4];
+    std::string serial_usd, graf, mecc;
     int lanIndex;
     int circleIndex;
     int usdCircleIndex;
@@ -70,12 +69,12 @@ void CSRTActiveSurfaceBossSectorThread::runLoop()
 
         try
         {
-            current_usd = m_boss->m_services->getComponent<ActiveSurface::USD>(serial_usd);
+            current_usd = m_boss->m_services->getComponent<ActiveSurface::USD>(serial_usd.c_str());
         }
         catch (maciErrType::CannotGetComponentExImpl& ex)
         {
             _ADD_BACKTRACE(ComponentErrors::CouldntGetComponentExImpl,Impl,ex,std::string(m_thread_name + "::runLoop()").c_str());
-            Impl.setComponentName(serial_usd);
+            Impl.setComponentName(serial_usd.c_str());
             Impl.log(LM_DEBUG);
         }
 


### PR DESCRIPTION
This commit contains 2 fixes for 2 files that caused some errors while trying to compile with GCC 8.3.1. The rest of the repository compiles and seems to work correctly in a simulated environment.