### PR TITLE
Fix #785, check schedule name, not whole path name

### DIFF
--- a/Common/Servers/Scheduler/src/Schedule.cpp
+++ b/Common/Servers/Scheduler/src/Schedule.cpp
@@ -112,7 +112,7 @@ CBaseSchedule::~CBaseSchedule()
 bool CBaseSchedule::readAll(bool check)
 {
 	IRA::CString err;
-	if (m_fileName.GetLength()>MAX_SCHED_NAME_LEN) {
+	if (m_baseName.GetLength()>MAX_SCHED_NAME_LEN) {
 		m_lastError.Format("Schedule name exceeds the maximum allowed characters of %d",MAX_SCHED_NAME_LEN);
 		return false;
 	}


### PR DESCRIPTION
This is meant to fix the issue on the master branch, not on the centos_7_compatibility branch since it has been already been fixed there.