### PR TITLE
Fix #579, fixed DiscosBackendProtocol get-tpi func

### DIFF
--- a/Common/Libraries/DiscosBackendProtocol/include/command.hpp
+++ b/Common/Libraries/DiscosBackendProtocol/include/command.hpp
@@ -17,7 +17,7 @@ namespace DiscosBackend{
             static Message setConfiguration(string conf);
             static Message getIntegration(){return Message(REQUEST, "get-integration");};
             static Message setIntegration(int integration);
-            static Message getTpi(double, double){return Message(REQUEST, "get-tpi");};
+            static Message getTpi(double frequency = 0, double bandwidth = 0);
             static Message getTp0(){return Message(REQUEST, "get-tp0");};
             static Message time(){return Message(REQUEST, "time");};
             static Message start(unsigned long long utctimestamp = 0);

--- a/Common/Libraries/DiscosBackendProtocol/src/command.cpp
+++ b/Common/Libraries/DiscosBackendProtocol/src/command.cpp
@@ -19,6 +19,15 @@ Command::setIntegration(int integration)
 }
 
 Message
+Command::getTpi(double frequency, double bandwidth)
+{
+    Message command(REQUEST, "get-tpi");
+    command.add_argument<double>(frequency);
+    command.add_argument<double>(bandwidth);
+    return command;
+}
+
+Message
 Command::start(unsigned long long utctimestamp)
 {
     Message command(REQUEST, "start");


### PR DESCRIPTION
Frequency and bandwidth arguments are sent regardless. It is duty of the backend to check their values and answer accordingly.
My guess is that a frequency equal to 0 identifies the starting frequency of the current backend configuration, a bandwidth equal to 0 tells the backend to get all the remaining bandwidth > frequency for the current backend configuration.