### PR TITLE
Fix #784, added `acsStop` to `discosdown` script

### DIFF
--- a/Medicina/Misc/MedScripts/src/discosdown
+++ b/Medicina/Misc/MedScripts/src/discosdown
@@ -32,4 +32,4 @@
 
 #MASTERHOST will be replaced by make file @installation time with proper server address
 
-ssh -f -l discos MASTERHOST "/bin/bash --login -c 'echo Shutting down.... && killACS && echo ....it is all over'"
+ssh -f -l discos MASTERHOST "/bin/bash --login -c 'echo Shutting down.... && killACS && acsStop && echo ....it is all over'"

--- a/Noto/Misc/NotoScripts/src/discosdown
+++ b/Noto/Misc/NotoScripts/src/discosdown
@@ -32,4 +32,4 @@
 
 #MASTERHOST will be replaced by make file @installation time with proper server address
 
-ssh -f -l discos MASTERHOST "/bin/bash --login -c 'echo Shutting down.... && killACS && echo ....it is all over'"
+ssh -f -l discos MASTERHOST "/bin/bash --login -c 'echo Shutting down.... && killACS && acsStop && echo ....it is all over'"

--- a/SRT/Misc/SRTScripts/src/discosdown
+++ b/SRT/Misc/SRTScripts/src/discosdown
@@ -32,5 +32,5 @@
 
 #MASTERHOST will be replaced by make file @installation time with proper server address
 
-ssh -f -l discos MASTERHOST "/bin/bash --login -c 'echo Shutting down.... && killACS && echo ....it is all over'"
+ssh -f -l discos MASTERHOST "/bin/bash --login -c 'echo Shutting down.... && killACS && acsStop && echo ....it is all over'"
 


### PR DESCRIPTION
Calling `acsStop` after `killACS` removes the lock on the default ACS instance