### PR TITLE
Fix #827, SRT CDB now points to "extraData"

### DIFF
--- a/SRT/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
+++ b/SRT/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
@@ -9,7 +9,7 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              SchedDir="/discos-archive/schedules/"
              DataDir="/discos-archive/data/"
-             SystemDataDir="/discos-archive/auxiliary/"
+             SystemDataDir="/discos-archive/extraData/"
              LogDir="/discos-archive/logs/"
              ScheduleReportPath=""
              ScheduleBackuptPath=""

--- a/SRT/Configuration/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
+++ b/SRT/Configuration/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
@@ -9,7 +9,7 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              SchedDir="/discos-archive/schedules/"
              DataDir="/discos-archive/data/"
-             SystemDataDir="/discos-archive/auxiliary/"
+             SystemDataDir="/discos-archive/extraData/"
              LogDir="/discos-archive/logs/"
 	     	 ScheduleReportPath=""
 	     	 ScheduleBackuptPath=""


### PR DESCRIPTION
It does not point to "auxiliary" anymore.