### PR TITLE
Fix #887, commanded minor servo preset after offset

### DIFF
--- a/SRT/Servers/SRTMinorServo/src/SRTMinorServoBossCore.cpp
+++ b/SRT/Servers/SRTMinorServo/src/SRTMinorServoBossCore.cpp
@@ -681,9 +681,11 @@ void SRTMinorServoBossCore::clearUserOffsets(std::string servo_name)
         for(const auto& [servo_name, servo] : m_current_servos)
         {
             servo->clearUserOffsets();
-            if(motion_status == MOTION_STATUS_CONFIGURED)
+            if(motion_status == MOTION_STATUS_CONFIGURED || m_tracking_servos.find(servo_name) == m_tracking_servos.end())
             {
-                // We are not tracking but we need to update the servo position to load the offsets
+                // We get here in 2 different scenarios
+                // 1) The system is configured and is not tracking the elevation, therefore we ALWAYS need to update the position of the servo we just set the offset
+                // 2) The servo we set the offset is not a program track servo, therefore we need to update its position manually
                 servo->preset(ACS::doubleSeq());
             }
         }
@@ -701,9 +703,11 @@ void SRTMinorServoBossCore::clearUserOffsets(std::string servo_name)
     {
         auto servo = m_current_servos.at(servo_name);
         servo->clearUserOffsets();
-        if(motion_status == MOTION_STATUS_CONFIGURED)
+        if(motion_status == MOTION_STATUS_CONFIGURED || m_tracking_servos.find(servo_name) == m_tracking_servos.end())
         {
-            // We are not tracking but we need to update the servo position to load the offsets
+            // We get here in 2 different scenarios
+            // 1) The system is configured and is not tracking the elevation, therefore we ALWAYS need to update the position of the servo we just set the offset
+            // 2) The servo we set the offset is not a program track servo, therefore we need to update its position manually
             servo->preset(ACS::doubleSeq());
         }
     }
@@ -763,9 +767,11 @@ void SRTMinorServoBossCore::setUserOffset(std::string servo_axis_name, double of
         }
         servo->setUserOffset(axis_name.c_str(), offset);
 
-        if(m_motion_status.load() == MOTION_STATUS_CONFIGURED)
+        if(m_motion_status.load() == MOTION_STATUS_CONFIGURED || m_tracking_servos.find(servo_name) == m_tracking_servos.end())
         {
-            // We are not tracking but we need to update the servo position to load the offsets
+            // We get here in 2 different scenarios
+            // 1) The system is configured and is not tracking the elevation, therefore we ALWAYS need to update the position of the servo we just set the offset
+            // 2) The servo we set the offset is not a program track servo, therefore we need to update its position manually
             servo->preset(ACS::doubleSeq());
         }
     }
@@ -834,9 +840,11 @@ void SRTMinorServoBossCore::clearSystemOffsets(std::string servo_name)
         for(const auto& [servo_name, servo] : m_current_servos)
         {
             servo->clearSystemOffsets();
-            if(motion_status == MOTION_STATUS_CONFIGURED)
+            if(motion_status == MOTION_STATUS_CONFIGURED || m_tracking_servos.find(servo_name) == m_tracking_servos.end())
             {
-                // We are not tracking but we need to update the servo position to load the offsets
+                // We get here in 2 different scenarios
+                // 1) The system is configured and is not tracking the elevation, therefore we ALWAYS need to update the position of the servo we just set the offset
+                // 2) The servo we set the offset is not a program track servo, therefore we need to update its position manually
                 servo->preset(ACS::doubleSeq());
             }
         }
@@ -854,9 +862,11 @@ void SRTMinorServoBossCore::clearSystemOffsets(std::string servo_name)
     {
         auto servo = m_current_servos.at(servo_name);
         servo->clearSystemOffsets();
-        if(motion_status == MOTION_STATUS_CONFIGURED)
+        if(motion_status == MOTION_STATUS_CONFIGURED || m_tracking_servos.find(servo_name) == m_tracking_servos.end())
         {
-            // We are not tracking but we need to update the servo position to load the offsets
+            // We get here in 2 different scenarios
+            // 1) The system is configured and is not tracking the elevation, therefore we ALWAYS need to update the position of the servo we just set the offset
+            // 2) The servo we set the offset is not a program track servo, therefore we need to update its position manually
             servo->preset(ACS::doubleSeq());
         }
     }
@@ -912,9 +922,11 @@ void SRTMinorServoBossCore::setSystemOffset(std::string servo_axis_name, double 
         auto servo = m_current_servos.at(servo_name);
         servo->setSystemOffset(axis_name.c_str(), offset);
 
-        if(m_motion_status.load() == MOTION_STATUS_CONFIGURED)
+        if(m_motion_status.load() == MOTION_STATUS_CONFIGURED || m_tracking_servos.find(servo_name) == m_tracking_servos.end())
         {
-            // We are not tracking but we need to update the servo position to load the offsets
+            // We get here in 2 different scenarios
+            // 1) The system is configured and is not tracking the elevation, therefore we ALWAYS need to update the position of the servo we just set the offset
+            // 2) The servo we set the offset is not a program track servo, therefore we need to update its position manually
             servo->preset(ACS::doubleSeq());
         }
     }


### PR DESCRIPTION
This modification allows to update the position of a non-tracking minor servo (GFR, M3R) after a offset is commanded. This is necessary because the said servos will only accept the given offset without updating their position, therefore a preset command is always needed.
This will affect:
`setServoOffset=GFR_RZ`
`setServoOffset=M3R_RZ`
Causing these commands to set the offset AND update the servo position right afterwards.