### PR TITLE
Fix #908, sped up compilation of SRTActiveSurfaceGUIClient(s)

### DIFF
--- a/Medicina/Clients/MedicinaActiveSurfaceGUIClient/src/Makefile
+++ b/Medicina/Clients/MedicinaActiveSurfaceGUIClient/src/Makefile
@@ -134,9 +134,9 @@ QT_COMPILE_FILES = $(subst .cpp,,$(QT_UI_FILES_MOC) $(QT_UI_FILES_EXTERN_MOC_H) 
 
 #
 # <brief description of xxxxx program>
-MedicinaActiveSurfaceGUIClient_OBJECTS   = $(QT_COMPILE_FILES) MedicinaActiveSurfaceGUIui MedicinaActiveSurfaceCore MedicinaActiveSurfaceClientEventLoop MedicinaActiveSurfaceGUIClient 
+MedicinaActiveSurfaceGUIClient_OBJECTS   = $(QT_COMPILE_FILES) MedicinaActiveSurfaceGUIui MedicinaActiveSurfaceCore MedicinaActiveSurfaceClientEventLoop MedicinaActiveSurfaceGUIClient
 MedicinaActiveSurfaceGUIClient_LIBS      = IRALibrary ActiveSurfaceBossStubs MedicinaActiveSurfaceBossStubs ASErrors ComponentErrors ClientErrors ManagementErrors ManagmentDefinitionsStubs
-MedicinaActiveSurfaceManagementGUIClient_OBJECTS   = $(QT_COMPILE_FILES) MedicinaActiveSurfaceManagementGUIui MedicinaActiveSurfaceCore MedicinaActiveSurfaceClientEventLoop MedicinaActiveSurfaceGUIClient 
+MedicinaActiveSurfaceManagementGUIClient_OBJECTS   = $(QT_COMPILE_FILES) MedicinaActiveSurfaceGUIui MedicinaActiveSurfaceCore MedicinaActiveSurfaceClientEventLoop MedicinaActiveSurfaceGUIClient
 MedicinaActiveSurfaceManagementGUIClient_LIBS      = IRALibrary ActiveSurfaceBossStubs MedicinaActiveSurfaceBossStubs ASErrors ComponentErrors ClientErrors ManagementErrors ManagmentDefinitionsStubs
 
 $(PROG)_OBJECTS            = $(PROG)

--- a/Medicina/Clients/MedicinaActiveSurfaceGUIClient/src/MedicinaActiveSurfaceManagementGUIui.cpp
+++ b/Medicina/Clients/MedicinaActiveSurfaceGUIClient/src/MedicinaActiveSurfaceManagementGUIui.cpp
@@ -1,1 +1,0 @@
-MedicinaActiveSurfaceGUIui.cpp

--- a/Noto/Clients/NotoActiveSurfaceGUIClient/src/Makefile
+++ b/Noto/Clients/NotoActiveSurfaceGUIClient/src/Makefile
@@ -134,9 +134,9 @@ QT_COMPILE_FILES = $(subst .cpp,,$(QT_UI_FILES_MOC) $(QT_UI_FILES_EXTERN_MOC_H) 
 
 #
 # <brief description of xxxxx program>
-NotoActiveSurfaceGUIClient_OBJECTS   = $(QT_COMPILE_FILES) NotoActiveSurfaceGUIui NotoActiveSurfaceCore NotoActiveSurfaceClientEventLoop NotoActiveSurfaceGUIClient 
+NotoActiveSurfaceGUIClient_OBJECTS   = $(QT_COMPILE_FILES) NotoActiveSurfaceGUIui NotoActiveSurfaceCore NotoActiveSurfaceClientEventLoop NotoActiveSurfaceGUIClient
 NotoActiveSurfaceGUIClient_LIBS      = IRALibrary ActiveSurfaceBossStubs NotoActiveSurfaceBossStubs ASErrors ComponentErrors ClientErrors ManagementErrors ManagmentDefinitionsStubs
-NotoActiveSurfaceManagementGUIClient_OBJECTS   = $(QT_COMPILE_FILES) NotoActiveSurfaceManagementGUIui NotoActiveSurfaceCore NotoActiveSurfaceClientEventLoop NotoActiveSurfaceGUIClient 
+NotoActiveSurfaceManagementGUIClient_OBJECTS   = $(QT_COMPILE_FILES) NotoActiveSurfaceGUIui NotoActiveSurfaceCore NotoActiveSurfaceClientEventLoop NotoActiveSurfaceGUIClient
 NotoActiveSurfaceManagementGUIClient_LIBS      = IRALibrary ActiveSurfaceBossStubs NotoActiveSurfaceBossStubs ASErrors ComponentErrors ClientErrors ManagementErrors ManagmentDefinitionsStubs
 
 $(PROG)_OBJECTS            = $(PROG)

--- a/Noto/Clients/NotoActiveSurfaceGUIClient/src/NotoActiveSurfaceManagementGUIui.cpp
+++ b/Noto/Clients/NotoActiveSurfaceGUIClient/src/NotoActiveSurfaceManagementGUIui.cpp
@@ -1,1 +1,0 @@
-NotoActiveSurfaceGUIui.cpp

--- a/SRT/Clients/SRTActiveSurfaceGUIClient/src/Makefile
+++ b/SRT/Clients/SRTActiveSurfaceGUIClient/src/Makefile
@@ -134,9 +134,9 @@ QT_COMPILE_FILES = $(subst .cpp,,$(QT_UI_FILES_MOC) $(QT_UI_FILES_EXTERN_MOC_H) 
 
 #
 # <brief description of xxxxx program>
-SRTActiveSurfaceGUIClient_OBJECTS   = $(QT_COMPILE_FILES) SRTActiveSurfaceGUIui SRTActiveSurfaceCore SRTActiveSurfaceClientEventLoop SRTActiveSurfaceGUIClient 
+SRTActiveSurfaceGUIClient_OBJECTS   = $(QT_COMPILE_FILES) SRTActiveSurfaceGUIui SRTActiveSurfaceCore SRTActiveSurfaceClientEventLoop SRTActiveSurfaceGUIClient
 SRTActiveSurfaceGUIClient_LIBS      = IRALibrary ActiveSurfaceBossStubs SRTActiveSurfaceBossStubs ASErrors ComponentErrors ClientErrors ManagementErrors ManagmentDefinitionsStubs
-SRTActiveSurfaceManagementGUIClient_OBJECTS   = $(QT_COMPILE_FILES) SRTActiveSurfaceManagementGUIui SRTActiveSurfaceCore SRTActiveSurfaceClientEventLoop SRTActiveSurfaceGUIClient 
+SRTActiveSurfaceManagementGUIClient_OBJECTS   = $(QT_COMPILE_FILES) SRTActiveSurfaceGUIui SRTActiveSurfaceCore SRTActiveSurfaceClientEventLoop SRTActiveSurfaceGUIClient
 SRTActiveSurfaceManagementGUIClient_LIBS      = IRALibrary ActiveSurfaceBossStubs SRTActiveSurfaceBossStubs ASErrors ComponentErrors ClientErrors ManagementErrors ManagmentDefinitionsStubs
 
 $(PROG)_OBJECTS            = $(PROG)

--- a/SRT/Clients/SRTActiveSurfaceGUIClient/src/SRTActiveSurfaceManagementGUIui.cpp
+++ b/SRT/Clients/SRTActiveSurfaceGUIClient/src/SRTActiveSurfaceManagementGUIui.cpp
@@ -1,1 +1,0 @@
-SRTActiveSurfaceGUIui.cpp


### PR DESCRIPTION
Now it takes around 3:40 instead of 7+ minutes to compile the SRTActiveSurfaceGUIClient.
This is especially relevant when compiling from SystemMake since we cannot parallelize the build process by using `make -j`
@carlomigoni let me know if this should be applied to other stations as well.