### PR TITLE
Fix #908, set flag to speed up AS GUIs build

### DIFF
--- a/Medicina/Clients/MedicinaActiveSurfaceGUIClient/src/Makefile
+++ b/Medicina/Clients/MedicinaActiveSurfaceGUIClient/src/Makefile
@@ -18,7 +18,7 @@
 
 #
 # user definable C-compilation flags
-USER_CFLAGS = -DQT_THREAD_SUPPORT
+USER_CFLAGS = -DQT_THREAD_SUPPORT -fno-var-tracking-assignments
 
 #
 # additional include and library search paths

--- a/Noto/Clients/NotoActiveSurfaceGUIClient/src/Makefile
+++ b/Noto/Clients/NotoActiveSurfaceGUIClient/src/Makefile
@@ -18,7 +18,7 @@
 
 #
 # user definable C-compilation flags
-USER_CFLAGS = -DQT_THREAD_SUPPORT
+USER_CFLAGS = -DQT_THREAD_SUPPORT -fno-var-tracking-assignments
 
 #
 # additional include and library search paths

--- a/SRT/Clients/SRTActiveSurfaceGUIClient/src/Makefile
+++ b/SRT/Clients/SRTActiveSurfaceGUIClient/src/Makefile
@@ -18,7 +18,7 @@
 
 #
 # user definable C-compilation flags
-USER_CFLAGS = -DQT_THREAD_SUPPORT
+USER_CFLAGS = -DQT_THREAD_SUPPORT -fno-var-tracking-assignments
 
 #
 # additional include and library search paths


### PR DESCRIPTION
Every time we try to build a AS GUI, the process tries to build the objects with the flag -fvar-tracking-assignments enabled by default. The build process with this flag is never successful and the process prints a warning similar to:
"variable tracking size limit exceeded with -fvar-tracking-assignments, retrying without"
By disabling the flag in the makefile, we skip the first, always unsuccessful, attempt, saving a lot of time.
For example, SRT AS GUI, build on VM with 12 cores:
- without the patch:
```
time make -j
real	3m6.833s
user	6m29.747s
sys	0m5.841s
```
- with this PR patch:
```
time make -j
real	0m34.383s
user	1m26.925s
sys	0m5.926s
```

Building with the `-fno-var-tracking-assigment` flag specified is more than 5 times faster than without.