### PR TITLE
Fix #931, SRT MS axes positions are now comprehend the offset

### DIFF
--- a/SRT/CDB/alma/MINORSERVO/GFR/GFR.xml
+++ b/SRT/CDB/alma/MINORSERVO/GFR/GFR.xml
@@ -27,7 +27,7 @@
     <virtual_offsets description="Sequence, sum of user and system virtual axis offsets" />
     <virtual_user_offsets description="Sequence, virtual user axes offsets" />
     <virtual_system_offsets description="Sequence, virtual system axes offsets" />
-    <commanded_virtual_positions description="Sequence, latest commanded (via preset) virtual positions" />
+    <commanded_plain_virtual_positions description="Sequence, latest commanded plain virtual positions" />
     <in_use description="Boolean indicating whether the servo is in use in the current configuration" />
     <current_setup description="The name of the current configuration" />
     <error_code description="The type of error encountered" />

--- a/SRT/CDB/alma/MINORSERVO/M3R/M3R.xml
+++ b/SRT/CDB/alma/MINORSERVO/M3R/M3R.xml
@@ -27,7 +27,7 @@
     <virtual_offsets description="Sequence, sum of user and system virtual axis offsets" />
     <virtual_user_offsets description="Sequence, virtual user axes offsets" />
     <virtual_system_offsets description="Sequence, virtual system axes offsets" />
-    <commanded_virtual_positions description="Sequence, latest commanded (via preset) virtual positions" />
+    <commanded_plain_virtual_positions description="Sequence, latest commanded plain virtual positions" />
     <in_use description="Boolean indicating whether the servo is in use in the current configuration" />
     <current_setup description="The name of the current configuration" />
     <error_code description="The type of error encountered" />

--- a/SRT/CDB/alma/MINORSERVO/SRP/SRP.xml
+++ b/SRT/CDB/alma/MINORSERVO/SRP/SRP.xml
@@ -28,7 +28,7 @@
     <virtual_offsets description="Sequence, sum of user and system virtual axis offsets" />
     <virtual_user_offsets description="Sequence, virtual user axes offsets" />
     <virtual_system_offsets description="Sequence, virtual system axes offsets" />
-    <commanded_virtual_positions description="Sequence, latest commanded (via preset) virtual positions" />
+    <commanded_plain_virtual_positions description="Sequence, latest commanded plain virtual positions" />
     <in_use description="Boolean indicating whether the servo is in use in the current configuration" />
     <current_setup description="The name of the current configuration" />
     <error_code description="The type of error encountered" />

--- a/SRT/Configuration/CDB/alma/MINORSERVO/GFR/GFR.xml
+++ b/SRT/Configuration/CDB/alma/MINORSERVO/GFR/GFR.xml
@@ -27,7 +27,7 @@
     <virtual_offsets description="Sequence, sum of user and system virtual axis offsets" />
     <virtual_user_offsets description="Sequence, virtual user axes offsets" />
     <virtual_system_offsets description="Sequence, virtual system axes offsets" />
-    <commanded_virtual_positions description="Sequence, latest commanded (via preset) virtual positions" />
+    <commanded_plain_virtual_positions description="Sequence, latest commanded plain virtual positions" />
     <in_use description="Boolean indicating whether the servo is in use in the current configuration" />
     <current_setup description="The name of the current configuration" />
     <error_code description="The type of error encountered" />

--- a/SRT/Configuration/CDB/alma/MINORSERVO/M3R/M3R.xml
+++ b/SRT/Configuration/CDB/alma/MINORSERVO/M3R/M3R.xml
@@ -27,7 +27,7 @@
     <virtual_offsets description="Sequence, sum of user and system virtual axis offsets" />
     <virtual_user_offsets description="Sequence, virtual user axes offsets" />
     <virtual_system_offsets description="Sequence, virtual system axes offsets" />
-    <commanded_virtual_positions description="Sequence, latest commanded (via preset) virtual positions" />
+    <commanded_plain_virtual_positions description="Sequence, latest commanded plain virtual positions" />
     <in_use description="Boolean indicating whether the servo is in use in the current configuration" />
     <current_setup description="The name of the current configuration" />
     <error_code description="The type of error encountered" />

--- a/SRT/Configuration/CDB/alma/MINORSERVO/SRP/SRP.xml
+++ b/SRT/Configuration/CDB/alma/MINORSERVO/SRP/SRP.xml
@@ -28,7 +28,7 @@
     <virtual_offsets description="Sequence, sum of user and system virtual axis offsets" />
     <virtual_user_offsets description="Sequence, virtual user axes offsets" />
     <virtual_system_offsets description="Sequence, virtual system axes offsets" />
-    <commanded_virtual_positions description="Sequence, latest commanded (via preset) virtual positions" />
+    <commanded_plain_virtual_positions description="Sequence, latest commanded plain virtual positions" />
     <in_use description="Boolean indicating whether the servo is in use in the current configuration" />
     <current_setup description="The name of the current configuration" />
     <error_code description="The type of error encountered" />

--- a/SRT/Interfaces/SRTMinorServoInterface/idl/SRTMinorServo.idl
+++ b/SRT/Interfaces/SRTMinorServoInterface/idl/SRTMinorServo.idl
@@ -31,9 +31,8 @@ module MinorServo
 
         /**
          * This property returns the latest virtual positions commanded with a preset command.
-         * Offsets are not taken into account since they are added by the LDO system.
          */
-        readonly attribute ACS::ROdoubleSeq commanded_virtual_positions;
+        readonly attribute ACS::ROdoubleSeq commanded_plain_virtual_positions;
 
         /**
          * This property indicates whether the servo is in use in the current configuration

--- a/SRT/Outdated/CDB/alma/MINORSERVO/PFP/PFP.xml
+++ b/SRT/Outdated/CDB/alma/MINORSERVO/PFP/PFP.xml
@@ -28,7 +28,7 @@
     <virtual_offsets description="Sequence, sum of user and system virtual axis offsets" />
     <virtual_user_offsets description="Sequence, virtual user axes offsets" />
     <virtual_system_offsets description="Sequence, virtual system axes offsets" />
-    <commanded_virtual_positions description="Sequence, latest commanded (via preset) virtual positions" />
+    <commanded_plain_virtual_positions description="Sequence, latest commanded plain virtual positions" />
     <in_use description="Boolean indicating whether the servo is in use in the current configuration" />
     <current_setup description="The name of the current configuration" />
     <error_code description="The type of error encountered" />

--- a/SRT/Servers/SRTMinorServo/config/CDB/schemas/SRTMinorServo.xsd
+++ b/SRT/Servers/SRTMinorServo/config/CDB/schemas/SRTMinorServo.xsd
@@ -51,7 +51,7 @@
        <xs:sequence>
         <xs:element name="virtual_user_offsets" type="baci:ROdoubleSeq" /> 
         <xs:element name="virtual_system_offsets" type="baci:ROdoubleSeq" /> 
-        <xs:element name="commanded_virtual_positions" type="baci:ROdoubleSeq" />
+        <xs:element name="commanded_plain_virtual_positions" type="baci:ROdoubleSeq" />
         <xs:element name="in_use" type="mng:BooleanType" />
         <xs:element name="current_setup" type="baci:ROstring" />
         <xs:element name="error_code" type="ms:SRTMinorServoErrorType" />

--- a/SRT/Servers/SRTMinorServo/include/SRTMinorServoImpl.h
+++ b/SRT/Servers/SRTMinorServo/include/SRTMinorServoImpl.h
@@ -393,7 +393,7 @@ protected:
     std::vector<double> m_commanded_virtual_positions;
 
     /**
-     * Queue of positions assumed by the servo system in time.
+     * Queue of positions assumed by the servo system in time, they comprehend the LDO offsets.
      */
     SRTMinorServoPositionsQueue m_positions_queue;
 

--- a/SRT/Servers/SRTMinorServo/include/SRTMinorServoImpl.h
+++ b/SRT/Servers/SRTMinorServo/include/SRTMinorServoImpl.h
@@ -283,10 +283,10 @@ public:
     virtual ACS::ROdoubleSeq_ptr virtual_system_offsets();
 
     /**
-     * Returns a reference to the commanded_virtual_positions property implementation of the IDL interface.
-     * @return pointer to the read-only double sequence property commanded_virtual_positions.
+     * Returns a reference to the commanded_plain_virtual_positions property implementation of the IDL interface.
+     * @return pointer to the read-only double sequence property commanded_plain_virtual_positions.
      */
-    virtual ACS::ROdoubleSeq_ptr commanded_virtual_positions();
+    virtual ACS::ROdoubleSeq_ptr commanded_plain_virtual_positions();
 
     /**
      * Returns a reference to the in_use property implementation of the IDL interface.
@@ -388,9 +388,9 @@ protected:
     std::vector<double> m_system_offsets;
 
     /**
-     * Latest commanded virtual positions. It only takes into account the preset command.
+     * Latest commanded virtual positions.
      */
-    std::vector<double> m_commanded_virtual_positions;
+    std::vector<double> m_commanded_plain_virtual_positions;
 
     /**
      * Queue of positions assumed by the servo system in time, they comprehend the LDO offsets.
@@ -503,9 +503,9 @@ private:
     baci::SmartPropertyPointer<baci::ROdoubleSeq> m_virtual_system_offsets_ptr;
 
     /**
-     * Pointer to the commanded_virtual_positions property.
+     * Pointer to the commanded_plain_virtual_positions property.
      */
-    baci::SmartPropertyPointer<baci::ROdoubleSeq> m_commanded_virtual_positions_ptr;
+    baci::SmartPropertyPointer<baci::ROdoubleSeq> m_commanded_plain_virtual_positions_ptr;
 
     /**
      * Pointer to the in_use property.
@@ -584,7 +584,7 @@ protected:
     virtual ACS::ROdoubleSeq_ptr virtual_offsets()                                              { return SRTBaseMinorServoImpl::virtual_offsets();                      }\
     virtual ACS::ROdoubleSeq_ptr virtual_user_offsets()                                         { return SRTBaseMinorServoImpl::virtual_user_offsets();                 }\
     virtual ACS::ROdoubleSeq_ptr virtual_system_offsets()                                       { return SRTBaseMinorServoImpl::virtual_system_offsets();               }\
-    virtual ACS::ROdoubleSeq_ptr commanded_virtual_positions()                                  { return SRTBaseMinorServoImpl::commanded_virtual_positions();          }\
+    virtual ACS::ROdoubleSeq_ptr commanded_plain_virtual_positions()                            { return SRTBaseMinorServoImpl::commanded_plain_virtual_positions();    }\
     virtual Management::ROTBoolean_ptr in_use()                                                 { return SRTBaseMinorServoImpl::in_use();                               }\
     virtual ACS::ROstring_ptr current_setup()                                                   { return SRTBaseMinorServoImpl::current_setup();                        }\
     virtual ROSRTMinorServoError_ptr error_code()                                               { return SRTBaseMinorServoImpl::error_code();                           }

--- a/SRT/Servers/SRTMinorServo/src/SRTBaseMinorServoImpl.cpp
+++ b/SRT/Servers/SRTMinorServo/src/SRTBaseMinorServoImpl.cpp
@@ -20,7 +20,7 @@ SRTBaseMinorServoImpl::SRTBaseMinorServoImpl(const ACE_CString& component_name, 
     m_error_code(ERROR_NO_ERROR),
     m_user_offsets(m_virtual_axes, 0.0),
     m_system_offsets(m_virtual_axes, 0.0),
-    m_commanded_virtual_positions(m_virtual_axes, 0.0),
+    m_commanded_plain_virtual_positions(m_virtual_axes, 0.0),
     m_positions_queue(5 * 60 * int(1 / getCDBValue<double>(container_services, "status_thread_period", "/MINORSERVO/Boss")), m_virtual_axes),
     m_min(SRTBaseMinorServoImpl::getMotionConstant(*this, "min_range")),
     m_max(SRTBaseMinorServoImpl::getMotionConstant(*this, "max_range")),
@@ -43,7 +43,7 @@ SRTBaseMinorServoImpl::SRTBaseMinorServoImpl(const ACE_CString& component_name, 
     m_virtual_offsets_ptr(this),
     m_virtual_user_offsets_ptr(this),
     m_virtual_system_offsets_ptr(this),
-    m_commanded_virtual_positions_ptr(this),
+    m_commanded_plain_virtual_positions_ptr(this),
     m_in_use_ptr(this),
     m_current_setup_ptr(this),
     m_error_code_ptr(this),
@@ -89,8 +89,8 @@ void SRTBaseMinorServoImpl::initialize()
                 new MSGenericDevIO<ACS::doubleSeq, std::vector<double>>(m_user_offsets), true);
         m_virtual_system_offsets_ptr = new baci::ROdoubleSeq((m_component_name + ":virtual_system_offsets").c_str(), getComponent(),
                 new MSGenericDevIO<ACS::doubleSeq, std::vector<double>>(m_system_offsets), true);
-        m_commanded_virtual_positions_ptr = new baci::ROdoubleSeq((m_component_name + ":commanded_virtual_positions").c_str(), getComponent(),
-                new MSGenericDevIO<ACS::doubleSeq, std::vector<double>>(m_commanded_virtual_positions), true);
+        m_commanded_plain_virtual_positions_ptr = new baci::ROdoubleSeq((m_component_name + ":commanded_plain_virtual_positions").c_str(), getComponent(),
+                new MSGenericDevIO<ACS::doubleSeq, std::vector<double>>(m_commanded_plain_virtual_positions), true);
         m_in_use_ptr = new ROEnumImpl<ACS_ENUM_T(Management::TBoolean), POA_Management::ROTBoolean>((m_component_name + ":in_use").c_str(), getComponent(),
                 new MSGenericDevIO<Management::TBoolean, std::atomic<Management::TBoolean>>(m_in_use), true);
         m_current_setup_ptr = new baci::ROstring((m_component_name + ":current_setup").c_str(), getComponent(),
@@ -215,8 +215,8 @@ void SRTBaseMinorServoImpl::preset(const ACS::doubleSeq& virtual_coords)
     if(virtual_coordinates.length() == 0)
     {
         // It means we want to command the latest coordinates again, to apply the offset in the LDO servo system
-        virtual_coordinates.length(m_commanded_virtual_positions.size());
-        std::copy(m_commanded_virtual_positions.begin(), m_commanded_virtual_positions.end(), virtual_coordinates.begin());
+        virtual_coordinates.length(m_commanded_plain_virtual_positions.size());
+        std::copy(m_commanded_plain_virtual_positions.begin(), m_commanded_plain_virtual_positions.end(), virtual_coordinates.begin());
     }
 
     if(virtual_coordinates.length() != m_virtual_axes)
@@ -251,7 +251,7 @@ void SRTBaseMinorServoImpl::preset(const ACS::doubleSeq& virtual_coords)
         throw ex.getMinorServoErrorsEx();
     }
 
-    std::copy(coordinates.begin(), coordinates.end(), m_commanded_virtual_positions.begin());
+    std::copy(coordinates.begin(), coordinates.end(), m_commanded_plain_virtual_positions.begin());
 }
 
 bool SRTBaseMinorServoImpl::setup(const char* configuration_name, CORBA::Boolean as_off)
@@ -353,7 +353,7 @@ bool SRTBaseMinorServoImpl::setup(const char* configuration_name, CORBA::Boolean
         // The positions tables inside the Leonardo minor servo systems are calculated with an elevation of 45 degrees.
         // We need to be sure the values are correct otherwise there will be a discrepancy.
         ACS::doubleSeq commanded_coordinates = *calcCoordinates(45);
-        std::copy(commanded_coordinates.begin(), commanded_coordinates.end(), m_commanded_virtual_positions.begin());
+        std::copy(commanded_coordinates.begin(), commanded_coordinates.end(), m_commanded_plain_virtual_positions.begin());
         return true;
     }
     else
@@ -898,7 +898,7 @@ GET_PROPERTY_REFERENCE(ACS::ROdoubleSeq, SRTBaseMinorServoImpl, m_virtual_positi
 GET_PROPERTY_REFERENCE(ACS::ROdoubleSeq, SRTBaseMinorServoImpl, m_virtual_offsets_ptr, virtual_offsets);
 GET_PROPERTY_REFERENCE(ACS::ROdoubleSeq, SRTBaseMinorServoImpl, m_virtual_user_offsets_ptr, virtual_user_offsets);
 GET_PROPERTY_REFERENCE(ACS::ROdoubleSeq, SRTBaseMinorServoImpl, m_virtual_system_offsets_ptr, virtual_system_offsets);
-GET_PROPERTY_REFERENCE(ACS::ROdoubleSeq, SRTBaseMinorServoImpl, m_commanded_virtual_positions_ptr, commanded_virtual_positions);
+GET_PROPERTY_REFERENCE(ACS::ROdoubleSeq, SRTBaseMinorServoImpl, m_commanded_plain_virtual_positions_ptr, commanded_plain_virtual_positions);
 GET_PROPERTY_REFERENCE(Management::ROTBoolean, SRTBaseMinorServoImpl, m_in_use_ptr, in_use);
 GET_PROPERTY_REFERENCE(ACS::ROstring, SRTBaseMinorServoImpl, m_current_setup_ptr, current_setup);
 GET_PROPERTY_REFERENCE(ROSRTMinorServoError, SRTBaseMinorServoImpl, m_error_code_ptr, error_code);

--- a/SRT/Servers/SRTMinorServo/src/SRTProgramTrackMinorServoImpl.cpp
+++ b/SRT/Servers/SRTMinorServo/src/SRTProgramTrackMinorServoImpl.cpp
@@ -69,7 +69,7 @@ bool SRTProgramTrackMinorServoImpl::status()
             // The tracking timestamp is interpolated instead
             std::pair<ACS::Time, std::vector<double>> tracking_point = m_tracking_queue.get(last_timestamp);
             commanded_positions = tracking_point.second;
-            m_commanded_virtual_positions = commanded_positions;
+            m_commanded_plain_virtual_positions = commanded_positions;
 
             m_remaining_trajectory_points.store(m_tracking_queue.getRemainingPoints(last_timestamp));
 
@@ -93,7 +93,7 @@ bool SRTProgramTrackMinorServoImpl::status()
     }
     else if(operative_mode == OPERATIVE_MODE_SETUP || operative_mode == OPERATIVE_MODE_PRESET)
     {
-        commanded_positions = m_commanded_virtual_positions;
+        commanded_positions = m_commanded_plain_virtual_positions;
         for(size_t i = 0; i < m_virtual_axes; i++)
         {
             commanded_positions[i] += m_user_offsets[i] + m_system_offsets[i];


### PR DESCRIPTION
The axes positions ending up in the fits file now are comprehensive of their user and system offsets, like it used to be in the old implementation.