### PR TITLE
Fix #973, added maxScanID and maxSubScanID to Scheduler component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/
                  https://discosclient.readthedocs.io/en/latest/schemas/schemas.html.
                  A ZMQ relay for commands has also been implemented. It relays commands to the ManagementContainer just like the OperatorInput default behavior.
                  More information regarding the whole ZMQ layer here: https://discosclient.readthedocs.io/en/latest/index.html
+    issue #973 - Added lastScanID and lastSubScanID to Scheduler component
 ## Fixed
     issue #940 - The SRTMinorServo components has been reworked in order to correctly handle socket reconnections. The component can now start as disconnected and still provide
                  information regarding its status via ZMQ.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/
                  https://discosclient.readthedocs.io/en/latest/schemas/schemas.html.
                  A ZMQ relay for commands has also been implemented. It relays commands to the ManagementContainer just like the OperatorInput default behavior.
                  More information regarding the whole ZMQ layer here: https://discosclient.readthedocs.io/en/latest/index.html
-    issue #973 - Added lastScanID and lastSubScanID to Scheduler component
+    issue #973 - Added maxScanID and maxSubScanID to Scheduler component
 ## Fixed
     issue #940 - The SRTMinorServo components has been reworked in order to correctly handle socket reconnections. The component can now start as disconnected and still provide
                  information regarding its status via ZMQ.

--- a/Common/Clients/SchedulerTextClient/src/SchedulerTuiClient.cpp
+++ b/Common/Clients/SchedulerTextClient/src/SchedulerTuiClient.cpp
@@ -143,8 +143,8 @@ int main(int argc, char *argv[]) {
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_ROSTRING> *schedule_field;
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *scanID_field;
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *subScanID_field;
-	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *lastScanID_field;
-	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *lastSubScanID_field;
+	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *maxScanID_field;
+	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *maxSubScanID_field;
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_ROSTRING> *currentBackend_field;
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_ROSTRING> *currentRecorder_field;
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *currentDevice_field;
@@ -241,8 +241,8 @@ int main(int argc, char *argv[]) {
 		_GET_ACS_PROPERTY(ACS::ROstring,projectCode);
 		_GET_ACS_PROPERTY(ACS::ROlong,scanID);
 		_GET_ACS_PROPERTY(ACS::ROlong,subScanID);
-		_GET_ACS_PROPERTY(ACS::ROlong,lastScanID);
-		_GET_ACS_PROPERTY(ACS::ROlong,lastSubScanID);
+		_GET_ACS_PROPERTY(ACS::ROlong,maxScanID);
+		_GET_ACS_PROPERTY(ACS::ROlong,maxSubScanID);
 		_GET_ACS_PROPERTY(ACS::ROstring,scheduleName);
 		_GET_ACS_PROPERTY(ACS::ROstring,currentBackend);
 		_GET_ACS_PROPERTY(ACS::ROstring,currentRecorder);
@@ -260,8 +260,8 @@ int main(int argc, char *argv[]) {
 		schedule_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_ROSTRING>(scheduleName.in());
 		scanID_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(scanID.in());
 		subScanID_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(subScanID.in());
-		lastScanID_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(lastScanID.in());
-		lastSubScanID_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(lastSubScanID.in());
+		maxScanID_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(maxScanID.in());
+		maxSubScanID_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(maxSubScanID.in());
 		currentDevice_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(currentDevice.in());
 		tracking_display=new TW::CPropertyLedDisplay<TEMPLATE_4_ROTBOOLEAN>(tracking.in());
 		status_box=new TW::CPropertyStatusBox<TEMPLATE_4_ROTSYSTEMSTATUS,Management::TSystemStatus>(status.in(),Management::MNG_OK) ;
@@ -284,14 +284,14 @@ int main(int argc, char *argv[]) {
 		strncpy(frm,"%04ld",8);
 		scanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
 		scanID_field->setWAlign(CFrameComponent::RIGHT);
-		_TW_SET_COMPONENT(lastScanID_field,25,2,4,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
-		lastScanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
+		_TW_SET_COMPONENT(maxScanID_field,25,2,4,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
+		maxScanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
 
 		_TW_SET_COMPONENT(subScanID_field,20,3,4,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
 		subScanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
 		subScanID_field->setWAlign(CFrameComponent::RIGHT);
-		_TW_SET_COMPONENT(lastSubScanID_field,25,3,4,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
-		lastSubScanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
+		_TW_SET_COMPONENT(maxSubScanID_field,25,3,4,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
+		maxSubScanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
 
 		_TW_SET_COMPONENT(currentBackend_field,20,4,24,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
 		_TW_SET_COMPONENT(currentRecorder_field,20,5,24,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
@@ -322,8 +322,8 @@ int main(int argc, char *argv[]) {
 		_INSTALL_MONITOR(schedule_field,1000);
 		_INSTALL_MONITOR(scanID_field,1000);
 		_INSTALL_MONITOR(subScanID_field,1000);
-		_INSTALL_MONITOR(lastScanID_field,1000);
-		_INSTALL_MONITOR(lastSubScanID_field,1000);
+		_INSTALL_MONITOR(maxScanID_field,1000);
+		_INSTALL_MONITOR(maxSubScanID_field,1000);
 		_INSTALL_MONITOR(projectCode_field,1000);
 		_INSTALL_MONITOR(currentDevice_field,1000);
 		_INSTALL_MONITOR(tracking_display,200);
@@ -340,9 +340,9 @@ int main(int argc, char *argv[]) {
 		// Add all the static labels
 		_TW_ADD_LABEL("Project Code   :",0,0,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
 		_TW_ADD_LABEL("Schedule       :",0,1,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
-		_TW_ADD_LABEL("Scan/Last      :",0,2,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
+		_TW_ADD_LABEL("Scan/Max       :",0,2,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
 		_TW_ADD_LABEL("/",24,2,1,1,CColorPair::WHITE_BLACK,0,window);
-		_TW_ADD_LABEL("SubScan/Last   :",0,3,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
+		_TW_ADD_LABEL("SubScan/Max    :",0,3,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
 		_TW_ADD_LABEL("/",24,3,1,1,CColorPair::WHITE_BLACK,0,window);
 		_TW_ADD_LABEL("Backend        :",0,4,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
 		_TW_ADD_LABEL("Recorder       :",0,5,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
@@ -356,8 +356,8 @@ int main(int argc, char *argv[]) {
 		window.addComponent((CFrameComponent*)schedule_field);
 		window.addComponent((CFrameComponent*)scanID_field);
 		window.addComponent((CFrameComponent*)subScanID_field);
-		window.addComponent((CFrameComponent*)lastScanID_field);
-		window.addComponent((CFrameComponent*)lastSubScanID_field);
+		window.addComponent((CFrameComponent*)maxScanID_field);
+		window.addComponent((CFrameComponent*)maxSubScanID_field);
 		window.addComponent((CFrameComponent*)projectCode_field);
 		window.addComponent((CFrameComponent*)currentDevice_field);
 		window.addComponent((CFrameComponent*)tracking_display);

--- a/Common/Clients/SchedulerTextClient/src/SchedulerTuiClient.cpp
+++ b/Common/Clients/SchedulerTextClient/src/SchedulerTuiClient.cpp
@@ -143,6 +143,8 @@ int main(int argc, char *argv[]) {
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_ROSTRING> *schedule_field;
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *scanID_field;
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *subScanID_field;
+	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *lastScanID_field;
+	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *lastSubScanID_field;
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_ROSTRING> *currentBackend_field;
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_ROSTRING> *currentRecorder_field;
 	TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)> *currentDevice_field;
@@ -239,6 +241,8 @@ int main(int argc, char *argv[]) {
 		_GET_ACS_PROPERTY(ACS::ROstring,projectCode);
 		_GET_ACS_PROPERTY(ACS::ROlong,scanID);
 		_GET_ACS_PROPERTY(ACS::ROlong,subScanID);
+		_GET_ACS_PROPERTY(ACS::ROlong,lastScanID);
+		_GET_ACS_PROPERTY(ACS::ROlong,lastSubScanID);
 		_GET_ACS_PROPERTY(ACS::ROstring,scheduleName);
 		_GET_ACS_PROPERTY(ACS::ROstring,currentBackend);
 		_GET_ACS_PROPERTY(ACS::ROstring,currentRecorder);
@@ -256,6 +260,8 @@ int main(int argc, char *argv[]) {
 		schedule_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_ROSTRING>(scheduleName.in());
 		scanID_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(scanID.in());
 		subScanID_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(subScanID.in());
+		lastScanID_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(lastScanID.in());
+		lastSubScanID_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(lastSubScanID.in());
 		currentDevice_field=new TW::CPropertyText<_TW_PROPERTYCOMPONENT_T_RO(long)>(currentDevice.in());
 		tracking_display=new TW::CPropertyLedDisplay<TEMPLATE_4_ROTBOOLEAN>(tracking.in());
 		status_box=new TW::CPropertyStatusBox<TEMPLATE_4_ROTSYSTEMSTATUS,Management::TSystemStatus>(status.in(),Management::MNG_OK) ;
@@ -278,20 +284,27 @@ int main(int argc, char *argv[]) {
 		strncpy(frm,"%04ld",8);
 		scanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
 		scanID_field->setWAlign(CFrameComponent::RIGHT);
-		_TW_SET_COMPONENT(subScanID_field,25,2,4,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
-		subScanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
-		_TW_SET_COMPONENT(currentBackend_field,20,3,24,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
-		_TW_SET_COMPONENT(currentRecorder_field,20,4,24,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
-		_TW_SET_COMPONENT(currentDevice_field,20,5,7,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
+		_TW_SET_COMPONENT(lastScanID_field,25,2,4,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
+		lastScanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
 
-		_TW_SET_COMPONENT(restFrequency_text,20,6,WINDOW_WIDTH-18,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
+		_TW_SET_COMPONENT(subScanID_field,20,3,4,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
+		subScanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
+		subScanID_field->setWAlign(CFrameComponent::RIGHT);
+		_TW_SET_COMPONENT(lastSubScanID_field,25,3,4,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
+		lastSubScanID_field->setFormatFunction(CFormatFunctions::integerFormat,static_cast<const void *>(frm));
+
+		_TW_SET_COMPONENT(currentBackend_field,20,4,24,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
+		_TW_SET_COMPONENT(currentRecorder_field,20,5,24,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
+		_TW_SET_COMPONENT(currentDevice_field,20,6,7,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
+
+		_TW_SET_COMPONENT(restFrequency_text,20,7,WINDOW_WIDTH-18,1,CColorPair::WHITE_BLACK,CStyle::BOLD,output_label);
 		restFrequency_text->setWAlign(CFrameComponent::LEFT);
 		restFrequency_text->setFormatFunction(CFormatFunctions::floatingPointFormat,"%.1lf");
-		tracking_display->setPosition(CPoint(20,7));
+		tracking_display->setPosition(CPoint(20,8));
 		tracking_display->setOrientation(TW::CPropertyLedDisplay<TEMPLATE_4_ROTBOOLEAN>::HORIZONTAL);
 		tracking_display->setFormatFunction(trackingFormat,NULL);
 		tracking_display->setLedStyle(0,TW::CStyle(CColorPair::GREEN_BLACK,0),TW::CStyle(CColorPair::RED_BLACK,0));
-		_TW_SET_COMPONENT(status_box,20,8,10,1,BLACK_GREEN,CStyle::BOLD,output_label);
+		_TW_SET_COMPONENT(status_box,20,9,10,1,BLACK_GREEN,CStyle::BOLD,output_label);
 		status_box->setStatusLook(Management::MNG_OK,CStyle(BLACK_GREEN,CStyle::BOLD));
 		status_box->setStatusLook(Management::MNG_WARNING,CStyle(BLACK_YELLOW,CStyle::BOLD));
 		status_box->setStatusLook(Management::MNG_FAILURE,CStyle(BLACK_RED,CStyle::BOLD));
@@ -309,6 +322,8 @@ int main(int argc, char *argv[]) {
 		_INSTALL_MONITOR(schedule_field,1000);
 		_INSTALL_MONITOR(scanID_field,1000);
 		_INSTALL_MONITOR(subScanID_field,1000);
+		_INSTALL_MONITOR(lastScanID_field,1000);
+		_INSTALL_MONITOR(lastSubScanID_field,1000);
 		_INSTALL_MONITOR(projectCode_field,1000);
 		_INSTALL_MONITOR(currentDevice_field,1000);
 		_INSTALL_MONITOR(tracking_display,200);
@@ -325,20 +340,24 @@ int main(int argc, char *argv[]) {
 		// Add all the static labels
 		_TW_ADD_LABEL("Project Code   :",0,0,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
 		_TW_ADD_LABEL("Schedule       :",0,1,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
-		_TW_ADD_LABEL("Scan/SubScan   :",0,2,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
+		_TW_ADD_LABEL("Scan/Last      :",0,2,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
 		_TW_ADD_LABEL("/",24,2,1,1,CColorPair::WHITE_BLACK,0,window);
-		_TW_ADD_LABEL("Backend        :",0,3,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
-		_TW_ADD_LABEL("Recorder       :",0,4,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
-		_TW_ADD_LABEL("Device         :",0,5,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
-		_TW_ADD_LABEL("Rest Freq.     :",0,6,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
-		_TW_ADD_LABEL("Tracking       :",0,7,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
-		_TW_ADD_LABEL("Status         :",0,8,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
+		_TW_ADD_LABEL("SubScan/Last   :",0,3,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
+		_TW_ADD_LABEL("/",24,3,1,1,CColorPair::WHITE_BLACK,0,window);
+		_TW_ADD_LABEL("Backend        :",0,4,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
+		_TW_ADD_LABEL("Recorder       :",0,5,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
+		_TW_ADD_LABEL("Device         :",0,6,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
+		_TW_ADD_LABEL("Rest Freq.     :",0,7,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
+		_TW_ADD_LABEL("Tracking       :",0,8,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
+		_TW_ADD_LABEL("Status         :",0,9,16,1,CColorPair::WHITE_BLACK,CStyle::UNDERLINE,window);
 		// *************************
 		
 		// Add all required association: components/Frame
 		window.addComponent((CFrameComponent*)schedule_field);
 		window.addComponent((CFrameComponent*)scanID_field);
 		window.addComponent((CFrameComponent*)subScanID_field);
+		window.addComponent((CFrameComponent*)lastScanID_field);
+		window.addComponent((CFrameComponent*)lastSubScanID_field);
 		window.addComponent((CFrameComponent*)projectCode_field);
 		window.addComponent((CFrameComponent*)currentDevice_field);
 		window.addComponent((CFrameComponent*)tracking_display);

--- a/Common/Interfaces/ManagmentInterface/idl/Scheduler.idl
+++ b/Common/Interfaces/ManagmentInterface/idl/Scheduler.idl
@@ -380,14 +380,14 @@ module Management {
 		readonly attribute ACS::ROlong subScanID;
 
 		/**
-		 * This attribute reports the last scan identifier in the currently played schedule.
+		 * This attribute reports the highest scan identifier in the currently played schedule.
 		 */
-		readonly attribute ACS::ROlong lastScanID;
+		readonly attribute ACS::ROlong maxScanID;
 
 		/**
-		 * This attribute reports the last subscan identifier inside the scan currently played by the scheduler
+		 * This attribute reports the highest subscan identifier inside the scan currently played by the scheduler
 		 */
-		readonly attribute ACS::ROlong lastSubScanID;
+		readonly attribute ACS::ROlong maxSubScanID;
 
 		/** 
 		 * This attribute reports the current schedule file name that the scheduler is executing.

--- a/Common/Interfaces/ManagmentInterface/idl/Scheduler.idl
+++ b/Common/Interfaces/ManagmentInterface/idl/Scheduler.idl
@@ -378,7 +378,17 @@ module Management {
 		 * This attribute reports the subscan identifier currently played by the scheduler
 		 */
 		readonly attribute ACS::ROlong subScanID;
-		
+
+		/**
+		 * This attribute reports the last scan identifier in the currently played schedule.
+		 */
+		readonly attribute ACS::ROlong lastScanID;
+
+		/**
+		 * This attribute reports the last subscan identifier inside the scan currently played by the scheduler
+		 */
+		readonly attribute ACS::ROlong lastSubScanID;
+
 		/** 
 		 * This attribute reports the current schedule file name that the scheduler is executing.
 		 */

--- a/Common/Servers/Scheduler/config/CDB/schemas/Scheduler.xsd
+++ b/Common/Servers/Scheduler/config/CDB/schemas/Scheduler.xsd
@@ -28,6 +28,8 @@
 			<xs:element name="scheduleName" type="baci:ROstring"/>
 			<xs:element name="scanID" type="baci:ROlong" />
 			<xs:element name="subScanID" type="baci:ROlong" />
+			<xs:element name="lastScanID" type="baci:ROlong" />
+			<xs:element name="lastSubScanID" type="baci:ROlong" />
 			<xs:element name="currentDevice" type="baci:ROlong" />
 			<xs:element name="status" type="mng:SystemStatusType" />
 			<xs:element name="tracking" type="mng:BooleanType" />	

--- a/Common/Servers/Scheduler/config/CDB/schemas/Scheduler.xsd
+++ b/Common/Servers/Scheduler/config/CDB/schemas/Scheduler.xsd
@@ -28,8 +28,8 @@
 			<xs:element name="scheduleName" type="baci:ROstring"/>
 			<xs:element name="scanID" type="baci:ROlong" />
 			<xs:element name="subScanID" type="baci:ROlong" />
-			<xs:element name="lastScanID" type="baci:ROlong" />
-			<xs:element name="lastSubScanID" type="baci:ROlong" />
+			<xs:element name="maxScanID" type="baci:ROlong" />
+			<xs:element name="maxSubScanID" type="baci:ROlong" />
 			<xs:element name="currentDevice" type="baci:ROlong" />
 			<xs:element name="status" type="mng:SystemStatusType" />
 			<xs:element name="tracking" type="mng:BooleanType" />	

--- a/Common/Servers/Scheduler/include/Core_Getter.h
+++ b/Common/Servers/Scheduler/include/Core_Getter.h
@@ -46,6 +46,13 @@ void getScanCounter(DWORD& cc);
  */
 void getCurrentIdentifiers(DWORD& scanID,DWORD& subScanID);
 
+/**
+ * This function reports the last identifiers of the current schedule and the current scan
+ * @param lastScanID last scan identifier in the schedule
+ * @param lastSubScanID last subscan identifier for the currently running scan
+ */
+void getLastIdentifiers(DWORD& lastScanID, DWORD& lastSubScanID);
+
 /**.
  * @param dv returns back  the current active data receiver
  */

--- a/Common/Servers/Scheduler/include/Core_Getter.h
+++ b/Common/Servers/Scheduler/include/Core_Getter.h
@@ -47,11 +47,11 @@ void getScanCounter(DWORD& cc);
 void getCurrentIdentifiers(DWORD& scanID,DWORD& subScanID);
 
 /**
- * This function reports the last identifiers of the current schedule and the current scan
- * @param lastScanID last scan identifier in the schedule
- * @param lastSubScanID last subscan identifier for the currently running scan
+ * This function reports the highest identifiers of the current schedule and the current scan
+ * @param maxScanID highest scan identifier in the schedule
+ * @param maxSubScanID highest subscan identifier for the currently running scan
  */
-void getLastIdentifiers(DWORD& lastScanID, DWORD& lastSubScanID);
+void getMaxIdentifiers(DWORD& maxScanID, DWORD& maxSubScanID);
 
 /**.
  * @param dv returns back  the current active data receiver

--- a/Common/Servers/Scheduler/include/DevIOLastScanNumber.h
+++ b/Common/Servers/Scheduler/include/DevIOLastScanNumber.h
@@ -1,0 +1,62 @@
+#ifndef DEVIOLASTSCANNUMBER_H_
+#define DEVIOLASTSCANNUMBER_H_
+
+/****************************************************************************************************************/
+/* This code is under GNU General Public Licence (GPL).                                                         */
+/*                                                                                                              */
+/* Who                                              When            What                                        */
+/* Giuseppe Carboni (giuseppe.carboni@inaf.it)      16/04/2026      Creation                                    */
+
+#include <baciDevIO.h>
+
+/**
+ * This class is derived from the template DevIO. It is used by the by the lastScanNumber and lastSubScanNumber properties. 
+ */ 
+class DevIOLastScanNumber: public virtual DevIO<CORBA::Long>
+{
+public:
+	
+	enum TSelector {
+		SCANID,
+		SUBSCANID
+	};
+
+	DevIOLastScanNumber(CCore* core,const TSelector& ss): m_core(core), m_selector(ss) {
+		AUTO_TRACE("DevIOLastScanNumber::DevIOLastScanNumber()");
+	}
+	
+	~DevIOLastScanNumber() {
+		AUTO_TRACE("DevIOLastScanNumber::~DevIOLastScanNumber()");
+	}
+	
+	bool initializeValue(){
+		return false;
+	}
+	
+	CORBA::Long read(ACS::Time& timestamp) throw (ACSErr::ACSbaseExImpl) {
+		AUTO_TRACE("DevIOLastScanNumber::read()");
+		DWORD  scanID, subScanID;
+		m_core->getLastIdentifiers(scanID,subScanID);
+		if (m_selector==SCANID) {
+			m_val=(CORBA::Long)scanID;
+		}
+		else {
+			m_val=(CORBA::Long)subScanID;
+		}
+		timestamp=getTimeStamp();
+		return m_val;
+    }
+	
+    void write(const CORBA::Long& value, ACS::Time& timestamp) throw (ACSErr::ACSbaseExImpl) {
+    	AUTO_TRACE("DevIOScanNumber::write()");
+	}
+    
+private:
+	CCore *m_core;
+	TSelector m_selector;
+	CORBA::Long m_val;
+};
+
+
+
+#endif /*DEVIOLASTSCANNUMBER_H_*/

--- a/Common/Servers/Scheduler/include/DevIOMaxScanNumber.h
+++ b/Common/Servers/Scheduler/include/DevIOMaxScanNumber.h
@@ -1,5 +1,5 @@
-#ifndef DEVIOLASTSCANNUMBER_H_
-#define DEVIOLASTSCANNUMBER_H_
+#ifndef DEVIOMAXSCANNUMBER_H_
+#define DEVIOMAXSCANNUMBER_H_
 
 /****************************************************************************************************************/
 /* This code is under GNU General Public Licence (GPL).                                                         */
@@ -10,9 +10,9 @@
 #include <baciDevIO.h>
 
 /**
- * This class is derived from the template DevIO. It is used by the by the lastScanNumber and lastSubScanNumber properties. 
+ * This class is derived from the template DevIO. It is used by the by the masScanNumber and maxSubScanNumber properties. 
  */ 
-class DevIOLastScanNumber: public virtual DevIO<CORBA::Long>
+class DevIOMaxScanNumber: public virtual DevIO<CORBA::Long>
 {
 public:
 	
@@ -21,12 +21,12 @@ public:
 		SUBSCANID
 	};
 
-	DevIOLastScanNumber(CCore* core,const TSelector& ss): m_core(core), m_selector(ss) {
-		AUTO_TRACE("DevIOLastScanNumber::DevIOLastScanNumber()");
+	DevIOMaxScanNumber(CCore* core,const TSelector& ss): m_core(core), m_selector(ss) {
+		AUTO_TRACE("DevIOMaxScanNumber::DevIOMaxScanNumber()");
 	}
 	
-	~DevIOLastScanNumber() {
-		AUTO_TRACE("DevIOLastScanNumber::~DevIOLastScanNumber()");
+	~DevIOMaxScanNumber() {
+		AUTO_TRACE("DevIOMaxScanNumber::~DevIOMaxScanNumber()");
 	}
 	
 	bool initializeValue(){
@@ -34,9 +34,9 @@ public:
 	}
 	
 	CORBA::Long read(ACS::Time& timestamp) throw (ACSErr::ACSbaseExImpl) {
-		AUTO_TRACE("DevIOLastScanNumber::read()");
+		AUTO_TRACE("DevIOMaxScanNumber::read()");
 		DWORD  scanID, subScanID;
-		m_core->getLastIdentifiers(scanID,subScanID);
+		m_core->getMaxIdentifiers(scanID,subScanID);
 		if (m_selector==SCANID) {
 			m_val=(CORBA::Long)scanID;
 		}
@@ -48,7 +48,7 @@ public:
     }
 	
     void write(const CORBA::Long& value, ACS::Time& timestamp) throw (ACSErr::ACSbaseExImpl) {
-    	AUTO_TRACE("DevIOScanNumber::write()");
+    	AUTO_TRACE("DevIOMaxScanNumber::write()");
 	}
     
 private:
@@ -59,4 +59,4 @@ private:
 
 
 
-#endif /*DEVIOLASTSCANNUMBER_H_*/
+#endif /*DEVIOMAXSCANNUMBER_H_*/

--- a/Common/Servers/Scheduler/include/Schedule.h
+++ b/Common/Servers/Scheduler/include/Schedule.h
@@ -924,16 +924,16 @@ public:
 	/**
 	 * @return the highest scan identifier parsed in the schedule
 	 */
-	DWORD getLastScanID() const { return m_lastScanID; }
+	DWORD getMaxScanID() const { return m_maxScanID; }
 
 	/**
 	 * @param scanID identifier of the scan
 	 * @return the highest subscan identifier for the given scan. Returns 0 if scan is not found.
 	 *
 	 */
-	DWORD getLastSubScanID(const DWORD& scanID) {
-		if (m_lastSubscans.find(scanID) != m_lastSubscans.end()) {
-			return m_lastSubscans[scanID];
+	DWORD getMaxSubScanID(const DWORD& scanID) {
+		if (m_maxSubscans.find(scanID) != m_maxSubscans.end()) {
+			return m_maxSubscans[scanID];
 		}
 		return 0;
 	}
@@ -970,8 +970,8 @@ private:
 		IRA::CString suffix;
 		IRA::CString layout;
 	} m_currentScanDef;
-	DWORD m_lastScanID;
-	std::map<DWORD, DWORD> m_lastSubscans;
+	DWORD m_maxScanID;
+	std::map<DWORD, DWORD> m_maxSubscans;
 
 
 

--- a/Common/Servers/Scheduler/include/Schedule.h
+++ b/Common/Servers/Scheduler/include/Schedule.h
@@ -920,6 +920,24 @@ public:
 	 * @param upper return back the upper value of the range, a negative means use system default
 	 */
 	void getElevationLimits(double&lower, double&upper) const { lower=m_lowerElevationLimit; upper=m_upperElevationLimit; }
+
+	/**
+	 * @return the highest scan identifier parsed in the schedule
+	 */
+	DWORD getLastScanID() const { return m_lastScanID; }
+
+	/**
+	 * @param scanID identifier of the scan
+	 * @return the highest subscan identifier for the given scan. Returns 0 if scan is not found.
+	 *
+	 */
+	DWORD getLastSubScanID(const DWORD& scanID) {
+		if (m_lastSubscans.find(scanID) != m_lastSubscans.end()) {
+			return m_lastSubscans[scanID];
+		}
+		return 0;
+	}
+
 private:
 	typedef std::vector<TRecord *> TSchedule;
 	typedef TSchedule::iterator TIterator;
@@ -952,6 +970,8 @@ private:
 		IRA::CString suffix;
 		IRA::CString layout;
 	} m_currentScanDef;
+	DWORD m_lastScanID;
+	std::map<DWORD, DWORD> m_lastSubscans;
 
 
 

--- a/Common/Servers/Scheduler/include/ScheduleExecutor.h
+++ b/Common/Servers/Scheduler/include/ScheduleExecutor.h
@@ -121,6 +121,11 @@ public:
      void getCurrentScanIdentifers(DWORD& scanID,DWORD& subScanID);
 
      /**
+      * @return the last identifiers of the current schedule and the current scan.
+      */
+     void getLastIdentifiers(DWORD& lastScanID, DWORD& lastSubScanID);
+
+     /**
       * Method is almost atomic, no sync required
       * @return true if a schedule is currently running
       */

--- a/Common/Servers/Scheduler/include/ScheduleExecutor.h
+++ b/Common/Servers/Scheduler/include/ScheduleExecutor.h
@@ -121,9 +121,9 @@ public:
      void getCurrentScanIdentifers(DWORD& scanID,DWORD& subScanID);
 
      /**
-      * @return the last identifiers of the current schedule and the current scan.
+      * @return the highest identifiers of the current schedule and the current scan.
       */
-     void getLastIdentifiers(DWORD& lastScanID, DWORD& lastSubScanID);
+     void getMaxIdentifiers(DWORD& maxScanID, DWORD& maxSubScanID);
 
      /**
       * Method is almost atomic, no sync required

--- a/Common/Servers/Scheduler/include/SchedulerImpl.h
+++ b/Common/Servers/Scheduler/include/SchedulerImpl.h
@@ -120,6 +120,18 @@ public:
 	virtual ACS::ROlong_ptr subScanID() throw (CORBA::SystemException);
 
 	/**
+	 * Returns a reference to the lastScanID property implementation of IDL interface.
+	 * @return pointer to read-only ROlong property status
+	 */
+	virtual ACS::ROlong_ptr lastScanID() throw (CORBA::SystemException);
+
+	/**
+	 * Returns a reference to the lastSubscanID property implementation of IDL interface.
+	 * @return pointer to read-only ROlong property status
+	 */
+	virtual ACS::ROlong_ptr lastSubScanID() throw (CORBA::SystemException);
+
+	/**
      * Returns a reference to the tracking property implementation of IDL interface.
 	 * @return pointer to read-only ROTBoolean property tracking
 	*/
@@ -484,6 +496,8 @@ private:
 	baci::SmartPropertyPointer < ROEnumImpl<ACS_ENUM_T(Management::TSystemStatus),POA_Management::ROTSystemStatus> > m_pstatus;
 	baci::SmartPropertyPointer<baci::ROlong> m_pscanID;
 	baci::SmartPropertyPointer<baci::ROlong> m_psubScanID;
+	baci::SmartPropertyPointer<baci::ROlong> m_plastScanID;
+	baci::SmartPropertyPointer<baci::ROlong> m_plastSubScanID;
 	baci::SmartPropertyPointer< ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean> > m_ptracking;
 	baci::SmartPropertyPointer<baci::ROlong> m_pcurrentDevice;
 	baci::SmartPropertyPointer<baci::ROstring> m_pprojectCode;

--- a/Common/Servers/Scheduler/include/SchedulerImpl.h
+++ b/Common/Servers/Scheduler/include/SchedulerImpl.h
@@ -120,16 +120,16 @@ public:
 	virtual ACS::ROlong_ptr subScanID() throw (CORBA::SystemException);
 
 	/**
-	 * Returns a reference to the lastScanID property implementation of IDL interface.
+	 * Returns a reference to the maxScanID property implementation of IDL interface.
 	 * @return pointer to read-only ROlong property status
 	 */
-	virtual ACS::ROlong_ptr lastScanID() throw (CORBA::SystemException);
+	virtual ACS::ROlong_ptr maxScanID() throw (CORBA::SystemException);
 
 	/**
-	 * Returns a reference to the lastSubscanID property implementation of IDL interface.
+	 * Returns a reference to the maxSubscanID property implementation of IDL interface.
 	 * @return pointer to read-only ROlong property status
 	 */
-	virtual ACS::ROlong_ptr lastSubScanID() throw (CORBA::SystemException);
+	virtual ACS::ROlong_ptr maxSubScanID() throw (CORBA::SystemException);
 
 	/**
      * Returns a reference to the tracking property implementation of IDL interface.
@@ -496,8 +496,8 @@ private:
 	baci::SmartPropertyPointer < ROEnumImpl<ACS_ENUM_T(Management::TSystemStatus),POA_Management::ROTSystemStatus> > m_pstatus;
 	baci::SmartPropertyPointer<baci::ROlong> m_pscanID;
 	baci::SmartPropertyPointer<baci::ROlong> m_psubScanID;
-	baci::SmartPropertyPointer<baci::ROlong> m_plastScanID;
-	baci::SmartPropertyPointer<baci::ROlong> m_plastSubScanID;
+	baci::SmartPropertyPointer<baci::ROlong> m_pmaxScanID;
+	baci::SmartPropertyPointer<baci::ROlong> m_pmaxSubScanID;
 	baci::SmartPropertyPointer< ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean> > m_ptracking;
 	baci::SmartPropertyPointer<baci::ROlong> m_pcurrentDevice;
 	baci::SmartPropertyPointer<baci::ROstring> m_pprojectCode;

--- a/Common/Servers/Scheduler/src/Core_Extra.i
+++ b/Common/Servers/Scheduler/src/Core_Extra.i
@@ -212,8 +212,8 @@ void CCore::publishZMQDictionary()
 	m_zmqDictionary["scanID"] = dwb1;
 	m_zmqDictionary["subScanID"] = dwb2;
 	getLastIdentifiers(dwb1, dwb2);
-	m_zmqDictionary["lastScanID"] = dwb1;
-	m_zmqDictionary["lastSubScanID"] = dwb2;
+	m_zmqDictionary["maxScanID"] = dwb1;
+	m_zmqDictionary["maxSubScanID"] = dwb2;
 	getScheduleName(str_buffer);
 	m_zmqDictionary["scheduleName"] = (const char*)str_buffer;
 

--- a/Common/Servers/Scheduler/src/Core_Extra.i
+++ b/Common/Servers/Scheduler/src/Core_Extra.i
@@ -211,6 +211,9 @@ void CCore::publishZMQDictionary()
 	getCurrentIdentifiers(dwb1, dwb2);
 	m_zmqDictionary["scanID"] = dwb1;
 	m_zmqDictionary["subScanID"] = dwb2;
+	getLastIdentifiers(dwb1, dwb2);
+	m_zmqDictionary["lastScanID"] = dwb1;
+	m_zmqDictionary["lastSubScanID"] = dwb2;
 	getScheduleName(str_buffer);
 	m_zmqDictionary["scheduleName"] = (const char*)str_buffer;
 

--- a/Common/Servers/Scheduler/src/Core_Getter.i
+++ b/Common/Servers/Scheduler/src/Core_Getter.i
@@ -27,6 +27,17 @@ void CCore::getCurrentIdentifiers(DWORD& scanID,DWORD& subScanID)
 	}
 }
 
+void CCore::getLastIdentifiers(DWORD& lastScanID, DWORD& lastSubScanID)
+{
+	if ((m_schedExecuter) && (m_schedExecuter->isScheduleActive())) {
+		m_schedExecuter->getLastIdentifiers(lastScanID, lastSubScanID);
+	}
+	else {
+		lastScanID = 0;
+		lastSubScanID = 0;
+	}
+}
+
 void CCore::getCurrentBackend(IRA::CString& bck)
 {
 	/*Backends::GenericBackend_var backend;

--- a/Common/Servers/Scheduler/src/Core_Getter.i
+++ b/Common/Servers/Scheduler/src/Core_Getter.i
@@ -27,14 +27,14 @@ void CCore::getCurrentIdentifiers(DWORD& scanID,DWORD& subScanID)
 	}
 }
 
-void CCore::getLastIdentifiers(DWORD& lastScanID, DWORD& lastSubScanID)
+void CCore::getMaxIdentifiers(DWORD& maxScanID, DWORD& maxSubScanID)
 {
 	if ((m_schedExecuter) && (m_schedExecuter->isScheduleActive())) {
-		m_schedExecuter->getLastIdentifiers(lastScanID, lastSubScanID);
+		m_schedExecuter->getMaxIdentifiers(maxScanID, maxSubScanID);
 	}
 	else {
-		lastScanID = 0;
-		lastSubScanID = 0;
+		maxScanID = 0;
+		maxSubScanID = 0;
 	}
 }
 

--- a/Common/Servers/Scheduler/src/Schedule.cpp
+++ b/Common/Servers/Scheduler/src/Schedule.cpp
@@ -541,9 +541,10 @@ bool CProcedureList::checkProcedure(const IRA::CString& conf,WORD args)
 
 CSchedule::CSchedule(const IRA::CString& path,const IRA::CString& fileName) : CBaseSchedule(path,fileName),m_projectName(""),m_observer(""),
 	m_scanList(""),m_configList(""),m_backendList(""),m_layoutFile(""),m_scanListUnit(NULL),m_preScanUnit(NULL),m_postScanUnit(NULL),m_backendListUnit(NULL),m_layoutListUnit(NULL),
-	m_mode(LST),m_repetitions(0),m_lowerElevationLimit(-1.0),m_upperElevationLimit(-1.0),m_scanTag(-1),m_modeDone(false),m_initProc(_SCHED_NULLTARGET),m_initProcArgs(0)
+	m_mode(LST),m_repetitions(0),m_lowerElevationLimit(-1.0),m_upperElevationLimit(-1.0),m_scanTag(-1),m_modeDone(false),m_initProc(_SCHED_NULLTARGET),m_initProcArgs(0),m_lastScanID(0)
 {
 	m_schedule.clear();
+	m_lastSubscans.clear();
 	m_currentScanDef.valid=false;
 	m_currentScanDef.line=m_currentScanDef.id=0;
 	m_currentScanDef.backendProc=m_currentScanDef.layout=m_currentScanDef.writerInstance=m_currentScanDef.suffix="";
@@ -1103,6 +1104,8 @@ bool CSchedule::parseScans(const IRA::CString& line,const DWORD& lnNumber,IRA::C
 					return false;
 				}
 				m_currentScanDef.id=tempId;
+
+				m_lastScanID = std::max(m_lastScanID, tempId);
 			}
 			if (!IRA::CIRATools::getNextToken(line,start,SEPARATORS,ret,false)) { //suffix
 				errorMsg="scan suffix cannot be found";
@@ -1168,6 +1171,7 @@ bool CSchedule::parseScans(const IRA::CString& line,const DWORD& lnNumber,IRA::C
 				errorMsg="subscan identifier cannot be zero";
 				return false;
 			}
+			m_lastSubscans[scanid] = std::max(m_lastSubscans[scanid], subscanid);
 			counter=m_schedule.size()+1; // subscan enumerations must start from 1
 			p=new TRecord;
 			p->line=lnNumber;
@@ -1206,6 +1210,7 @@ bool CSchedule::parseScans(const IRA::CString& line,const DWORD& lnNumber,IRA::C
 				errorMsg="subscan identifier cannot be zero";
 				return false;
 			}
+			m_lastSubscans[scanid] = std::max(m_lastSubscans[scanid], subscanid);
 			counter=m_schedule.size()+1; // subscan enumerations must start from 1
 			p=new TRecord;
 			p->line=lnNumber;

--- a/Common/Servers/Scheduler/src/Schedule.cpp
+++ b/Common/Servers/Scheduler/src/Schedule.cpp
@@ -541,10 +541,10 @@ bool CProcedureList::checkProcedure(const IRA::CString& conf,WORD args)
 
 CSchedule::CSchedule(const IRA::CString& path,const IRA::CString& fileName) : CBaseSchedule(path,fileName),m_projectName(""),m_observer(""),
 	m_scanList(""),m_configList(""),m_backendList(""),m_layoutFile(""),m_scanListUnit(NULL),m_preScanUnit(NULL),m_postScanUnit(NULL),m_backendListUnit(NULL),m_layoutListUnit(NULL),
-	m_mode(LST),m_repetitions(0),m_lowerElevationLimit(-1.0),m_upperElevationLimit(-1.0),m_scanTag(-1),m_modeDone(false),m_initProc(_SCHED_NULLTARGET),m_initProcArgs(0),m_lastScanID(0)
+	m_mode(LST),m_repetitions(0),m_lowerElevationLimit(-1.0),m_upperElevationLimit(-1.0),m_scanTag(-1),m_modeDone(false),m_initProc(_SCHED_NULLTARGET),m_initProcArgs(0),m_maxScanID(0)
 {
 	m_schedule.clear();
-	m_lastSubscans.clear();
+	m_maxSubscans.clear();
 	m_currentScanDef.valid=false;
 	m_currentScanDef.line=m_currentScanDef.id=0;
 	m_currentScanDef.backendProc=m_currentScanDef.layout=m_currentScanDef.writerInstance=m_currentScanDef.suffix="";
@@ -1105,7 +1105,7 @@ bool CSchedule::parseScans(const IRA::CString& line,const DWORD& lnNumber,IRA::C
 				}
 				m_currentScanDef.id=tempId;
 
-				m_lastScanID = std::max(m_lastScanID, tempId);
+				m_maxScanID = std::max(m_maxScanID, tempId);
 			}
 			if (!IRA::CIRATools::getNextToken(line,start,SEPARATORS,ret,false)) { //suffix
 				errorMsg="scan suffix cannot be found";
@@ -1171,7 +1171,7 @@ bool CSchedule::parseScans(const IRA::CString& line,const DWORD& lnNumber,IRA::C
 				errorMsg="subscan identifier cannot be zero";
 				return false;
 			}
-			m_lastSubscans[scanid] = std::max(m_lastSubscans[scanid], subscanid);
+			m_maxSubscans[scanid] = std::max(m_maxSubscans[scanid], subscanid);
 			counter=m_schedule.size()+1; // subscan enumerations must start from 1
 			p=new TRecord;
 			p->line=lnNumber;
@@ -1210,7 +1210,7 @@ bool CSchedule::parseScans(const IRA::CString& line,const DWORD& lnNumber,IRA::C
 				errorMsg="subscan identifier cannot be zero";
 				return false;
 			}
-			m_lastSubscans[scanid] = std::max(m_lastSubscans[scanid], subscanid);
+			m_maxSubscans[scanid] = std::max(m_maxSubscans[scanid], subscanid);
 			counter=m_schedule.size()+1; // subscan enumerations must start from 1
 			p=new TRecord;
 			p->line=lnNumber;

--- a/Common/Servers/Scheduler/src/ScheduleExecutor.cpp
+++ b/Common/Servers/Scheduler/src/ScheduleExecutor.cpp
@@ -523,7 +523,7 @@ void CScheduleExecutor::getCurrentScanIdentifers(DWORD& scanID,DWORD& subScanID)
 	}
 }
 
-void CScheduleExecutor::getLastIdentifiers(DWORD& lastScanID, DWORD& lastSubScanID)
+void CScheduleExecutor::getMaxIdentifiers(DWORD& maxScanID, DWORD& maxSubScanID)
 {
 	baci::ThreadSyncGuard guard(&m_mutex);
 
@@ -532,12 +532,12 @@ void CScheduleExecutor::getLastIdentifiers(DWORD& lastScanID, DWORD& lastSubScan
 
 		m_schedule->getIdentifiers(m_scheduleCounter, currentScanID, currentSubScanID);
 
-		lastScanID = m_schedule->getLastScanID();
-		lastSubScanID = m_schedule->getLastSubScanID(currentScanID);
+		maxScanID = m_schedule->getMaxScanID();
+		maxSubScanID = m_schedule->getMaxSubScanID(currentScanID);
 	}
 	else {
-		lastScanID = 0;
-		lastSubScanID = 0;
+		maxScanID = 0;
+		maxSubScanID = 0;
 	}
 }
 

--- a/Common/Servers/Scheduler/src/ScheduleExecutor.cpp
+++ b/Common/Servers/Scheduler/src/ScheduleExecutor.cpp
@@ -523,6 +523,24 @@ void CScheduleExecutor::getCurrentScanIdentifers(DWORD& scanID,DWORD& subScanID)
 	}
 }
 
+void CScheduleExecutor::getLastIdentifiers(DWORD& lastScanID, DWORD& lastSubScanID)
+{
+	baci::ThreadSyncGuard guard(&m_mutex);
+
+	if (m_schedule != NULL) {
+		DWORD currentScanID, currentSubScanID;
+
+		m_schedule->getIdentifiers(m_scheduleCounter, currentScanID, currentSubScanID);
+
+		lastScanID = m_schedule->getLastScanID();
+		lastSubScanID = m_schedule->getLastSubScanID(currentScanID);
+	}
+	else {
+		lastScanID = 0;
+		lastSubScanID = 0;
+	}
+}
+
 void CScheduleExecutor::initialize(maci::ContainerServices *services,const double& dut1,const IRA::CSite& site,CConfiguration* config)
 { 
 	 m_services=services;

--- a/Common/Servers/Scheduler/src/SchedulerImpl.cpp
+++ b/Common/Servers/Scheduler/src/SchedulerImpl.cpp
@@ -2,6 +2,7 @@
 #include "SchedulerImpl.h"
 #include "Core.h"
 #include "DevIOScanNumber.h"
+#include "DevIOLastScanNumber.h"
 #include "DevIOScheduleName.h"
 #include "DevIOStatus.h"
 #include "DevIOTracking.h"
@@ -20,6 +21,8 @@ SchedulerImpl::SchedulerImpl(const ACE_CString &CompName,maci::ContainerServices
 	m_pstatus(this),
 	m_pscanID(this),
 	m_psubScanID(this),
+	m_plastScanID(this),
+	m_plastSubScanID(this),
 	m_ptracking(this),
 	m_pcurrentDevice(this),
 	m_pprojectCode(this),
@@ -59,6 +62,8 @@ void SchedulerImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 				new DevIOStatus(m_core),true);
 		m_pscanID=new ROlong(getContainerServices()->getName()+":scanID",getComponent(),new DevIOScanNumber(m_core,DevIOScanNumber::SCANID),true);
 		m_psubScanID=new ROlong(getContainerServices()->getName()+":subScanID",getComponent(),new DevIOScanNumber(m_core,DevIOScanNumber::SUBSCANID),true);
+		m_plastScanID=new ROlong(getContainerServices()->getName()+":lastScanID",getComponent(),new DevIOLastScanNumber(m_core,DevIOLastScanNumber::SCANID),true);
+		m_plastSubScanID=new ROlong(getContainerServices()->getName()+":lastSubScanID",getComponent(),new DevIOLastScanNumber(m_core,DevIOLastScanNumber::SUBSCANID),true);
 		m_ptracking=new ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean>(getContainerServices()->getName()+":tracking",getComponent(),
 				new DevIOTracking(m_core),true);
 		m_pcurrentDevice=new ROlong(getContainerServices()->getName()+":currentDevice",getComponent(),new DevIOCurrentDevice(m_core),true);
@@ -625,6 +630,8 @@ _PROPERTY_REFERENCE_CPP(SchedulerImpl,Management::ROTSystemStatus,m_pstatus,stat
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROstring,m_pscheduleName,scheduleName);
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_pscanID,scanID);
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_psubScanID,subScanID);
+_PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_plastScanID,lastScanID);
+_PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_plastSubScanID,lastSubScanID);
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,Management::ROTBoolean,m_ptracking,tracking);
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_pcurrentDevice,currentDevice);
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROstring,m_pprojectCode,projectCode);

--- a/Common/Servers/Scheduler/src/SchedulerImpl.cpp
+++ b/Common/Servers/Scheduler/src/SchedulerImpl.cpp
@@ -2,7 +2,7 @@
 #include "SchedulerImpl.h"
 #include "Core.h"
 #include "DevIOScanNumber.h"
-#include "DevIOLastScanNumber.h"
+#include "DevIOMaxScanNumber.h"
 #include "DevIOScheduleName.h"
 #include "DevIOStatus.h"
 #include "DevIOTracking.h"
@@ -21,8 +21,8 @@ SchedulerImpl::SchedulerImpl(const ACE_CString &CompName,maci::ContainerServices
 	m_pstatus(this),
 	m_pscanID(this),
 	m_psubScanID(this),
-	m_plastScanID(this),
-	m_plastSubScanID(this),
+	m_pmaxScanID(this),
+	m_pmaxSubScanID(this),
 	m_ptracking(this),
 	m_pcurrentDevice(this),
 	m_pprojectCode(this),
@@ -62,8 +62,8 @@ void SchedulerImpl::initialize() throw (ACSErr::ACSbaseExImpl)
 				new DevIOStatus(m_core),true);
 		m_pscanID=new ROlong(getContainerServices()->getName()+":scanID",getComponent(),new DevIOScanNumber(m_core,DevIOScanNumber::SCANID),true);
 		m_psubScanID=new ROlong(getContainerServices()->getName()+":subScanID",getComponent(),new DevIOScanNumber(m_core,DevIOScanNumber::SUBSCANID),true);
-		m_plastScanID=new ROlong(getContainerServices()->getName()+":lastScanID",getComponent(),new DevIOLastScanNumber(m_core,DevIOLastScanNumber::SCANID),true);
-		m_plastSubScanID=new ROlong(getContainerServices()->getName()+":lastSubScanID",getComponent(),new DevIOLastScanNumber(m_core,DevIOLastScanNumber::SUBSCANID),true);
+		m_pmaxScanID=new ROlong(getContainerServices()->getName()+":maxScanID",getComponent(),new DevIOMaxScanNumber(m_core,DevIOMaxScanNumber::SCANID),true);
+		m_pmaxSubScanID=new ROlong(getContainerServices()->getName()+":maxSubScanID",getComponent(),new DevIOMaxScanNumber(m_core,DevIOMaxScanNumber::SUBSCANID),true);
 		m_ptracking=new ROEnumImpl<ACS_ENUM_T(Management::TBoolean),POA_Management::ROTBoolean>(getContainerServices()->getName()+":tracking",getComponent(),
 				new DevIOTracking(m_core),true);
 		m_pcurrentDevice=new ROlong(getContainerServices()->getName()+":currentDevice",getComponent(),new DevIOCurrentDevice(m_core),true);
@@ -630,8 +630,8 @@ _PROPERTY_REFERENCE_CPP(SchedulerImpl,Management::ROTSystemStatus,m_pstatus,stat
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROstring,m_pscheduleName,scheduleName);
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_pscanID,scanID);
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_psubScanID,subScanID);
-_PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_plastScanID,lastScanID);
-_PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_plastSubScanID,lastSubScanID);
+_PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_pmaxScanID,maxScanID);
+_PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_pmaxSubScanID,maxSubScanID);
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,Management::ROTBoolean,m_ptracking,tracking);
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROlong,m_pcurrentDevice,currentDevice);
 _PROPERTY_REFERENCE_CPP(SchedulerImpl,ACS::ROstring,m_pprojectCode,projectCode);

--- a/Medicina/CDB/alma/MANAGEMENT/Palmiro/Palmiro.xml
+++ b/Medicina/CDB/alma/MANAGEMENT/Palmiro/Palmiro.xml
@@ -36,6 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
+<lastScanID/>
+<lastSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/Medicina/CDB/alma/MANAGEMENT/Palmiro/Palmiro.xml
+++ b/Medicina/CDB/alma/MANAGEMENT/Palmiro/Palmiro.xml
@@ -36,8 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
-<lastScanID/>
-<lastSubScanID/>
+<maxScanID/>
+<maxSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/Medicina/Configuration/CDB/alma/MANAGEMENT/Palmiro/Palmiro.xml
+++ b/Medicina/Configuration/CDB/alma/MANAGEMENT/Palmiro/Palmiro.xml
@@ -36,6 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
+<lastScanID/>
+<lastSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/Medicina/Configuration/CDB/alma/MANAGEMENT/Palmiro/Palmiro.xml
+++ b/Medicina/Configuration/CDB/alma/MANAGEMENT/Palmiro/Palmiro.xml
@@ -36,8 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
-<lastScanID/>
-<lastSubScanID/>
+<maxScanID/>
+<maxSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/Noto/CDB/alma/MANAGEMENT/Ducezio/Ducezio.xml
+++ b/Noto/CDB/alma/MANAGEMENT/Ducezio/Ducezio.xml
@@ -36,6 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
+<lastScanID/>
+<lastSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/Noto/CDB/alma/MANAGEMENT/Ducezio/Ducezio.xml
+++ b/Noto/CDB/alma/MANAGEMENT/Ducezio/Ducezio.xml
@@ -36,8 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
-<lastScanID/>
-<lastSubScanID/>
+<maxScanID/>
+<maxSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/Noto/Configuration/CDB/alma/MANAGEMENT/Ducezio/Ducezio.xml
+++ b/Noto/Configuration/CDB/alma/MANAGEMENT/Ducezio/Ducezio.xml
@@ -36,6 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
+<lastScanID/>
+<lastSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/Noto/Configuration/CDB/alma/MANAGEMENT/Ducezio/Ducezio.xml
+++ b/Noto/Configuration/CDB/alma/MANAGEMENT/Ducezio/Ducezio.xml
@@ -36,8 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
-<lastScanID/>
-<lastSubScanID/>
+<maxScanID/>
+<maxSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/SRT/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
+++ b/SRT/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
@@ -36,6 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
+<lastScanID/>
+<lastSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/SRT/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
+++ b/SRT/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
@@ -36,8 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
-<lastScanID/>
-<lastSubScanID/>
+<maxScanID/>
+<maxSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/SRT/Configuration/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
+++ b/SRT/Configuration/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
@@ -36,6 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
+<lastScanID/>
+<lastSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>

--- a/SRT/Configuration/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
+++ b/SRT/Configuration/CDB/alma/MANAGEMENT/Gavino/Gavino.xml
@@ -36,8 +36,8 @@
 <scheduleName/>
 <scanID/>
 <subScanID/>
-<lastScanID/>
-<lastSubScanID/>
+<maxScanID/>
+<maxSubScanID/>
 <currentDevice/>
 <status/>
 <tracking/>


### PR DESCRIPTION
I added the two properties as mentioned in the title. They are both BACIProperties and ZMQ properties. I also updated the SchedulerTUI in order to show them to the users.

<img width="366" height="264" alt="Screenshot from 2026-04-17 08-00-23" src="https://github.com/user-attachments/assets/2117e624-2647-41ba-94c2-b3d15e948696" />