### PR TITLE
Fix #975, ReceiversBoss now sends available receivers

### DIFF
--- a/Common/Servers/ReceiversBoss/include/Configuration.h
+++ b/Common/Servers/ReceiversBoss/include/Configuration.h
@@ -79,6 +79,12 @@ public:
 	 */
 	inline const IRA::CString& dewarPositionerInterface() const {  return m_dewarPositionerInterface; }
 
+	/**
+	 * Retrieves the list of all available receivers codes.
+	 * @return set containing the available receiver codes
+	 */
+	const std::set<std::string>& getAvailableReceivers() const { return m_availableReceivers; }
+
 private:
 	TReceiver * m_receiver;
 	WORD m_receiverNum;
@@ -87,6 +93,7 @@ private:
 	DDWORD m_statusPersistenceTime;
 	DDWORD m_propertiesUpdateTime;
 	IRA::CString m_dewarPositionerInterface;
+	std::set<std::string> m_availableReceivers;
 };
 
 

--- a/Common/Servers/ReceiversBoss/src/Configuration.cpp
+++ b/Common/Servers/ReceiversBoss/src/Configuration.cpp
@@ -86,6 +86,12 @@ void CConfiguration::init(maci::ContainerServices *Services) throw (ComponentErr
 			break;
 		}
 		m_receiver[m_receiverNum].component=strVal;
+
+		std::string compName = (const char*)strVal;
+		size_t pos = compName.find_last_of('/');
+		std::string receiverName = (pos != std::string::npos) ? compName.substr(pos + 1) : compName;
+		m_availableReceivers.insert(receiverName);
+
 		m_receiverNum++;
 	}
 	ACS_DEBUG_PARAM("CConfiguration::Init()","Total available receivers: %d",m_receiverNum);
@@ -108,4 +114,3 @@ bool CConfiguration::getReceiver(const IRA::CString& code,IRA::CString& componen
 	}
 	return false;
 }
-

--- a/Common/Servers/ReceiversBoss/src/RecvBossCore.cpp
+++ b/Common/Servers/ReceiversBoss/src/RecvBossCore.cpp
@@ -1970,7 +1970,7 @@ void CRecvBossCore::updateZMQDictionary()
 	if(m_config->getReceiver(currentSetup.c_str(), component, derotator))
 	{
 		m_zmqDictionary["currentSetup"] = currentSetup;
-        std::string currentReceiver = (const char *)component;
+		std::string currentReceiver = (const char *)component;
 		m_zmqDictionary["currentReceiver"] = currentReceiver.substr(currentReceiver.find_last_of('/') != std::string::npos ? currentReceiver.find_last_of('/') + 1 : 0);
 	}
 	else
@@ -1979,7 +1979,7 @@ void CRecvBossCore::updateZMQDictionary()
 		m_zmqDictionary["currentReceiver"] = "";
 	}
 
-	m_zmqDictionary["timestamp"] = ZMQ::ZMQTimeStamp::now();
+	m_zmqDictionary["availableReceivers"] = m_config->getAvailableReceivers();
 
 	// status enum
 	switch (getStatus()) {
@@ -1996,6 +1996,8 @@ void CRecvBossCore::updateZMQDictionary()
 			break;
 		}
 	}
+
+	m_zmqDictionary["timestamp"] = ZMQ::ZMQTimeStamp::now();
 }
 
 void CRecvBossCore::publishData() throw (ComponentErrors::NotificationChannelErrorExImpl)


### PR DESCRIPTION
The ReceiversBoss component now sends a list of available receivers via ZMQPublisher. This information is crucial since ZMQ clients don't have access to ACS information and cannot be aware of availble receivers in any other way.